### PR TITLE
docs: README整備とタスクドキュメント分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Book Reading Record Web App
+
+読書記録（ページ進捗・完読感想・再読）を管理する単一ユーザー向けMVPです。
+
+## Repository Structure
+
+- `base/`: 参照用の既存MVP（read-only）
+- `front/`: 実装本体（Next.js / TypeScript / Tailwind CSS）
+- `docs/`: 要件・仕様・E2Eケース
+
+## MVP Features
+
+- 書籍登録（タイトル/著者/形式/総ページ/初期ステータス）
+- ページ進捗入力（絶対値）+ メモ + ステータス更新
+- 完読時感想（学び/行動/一文、空入力可）
+- 再読（完読 -> 読書中、`currentPage=0`）
+- ダッシュボード（読書前/読書中/保留/完読/感想未記入）
+- 検索（タイトル・著者・タグ）
+- 週次サマリー（読了ページ/進捗回数/感想数）
+- 統計レポート (`/stats`)
+
+## Local Development
+
+```bash
+cd front
+pnpm install
+pnpm test:e2e:install
+pnpm dev
+```
+
+Open: `http://localhost:3000`
+
+## Quality Checks
+
+```bash
+cd front
+pnpm format:check
+pnpm lint
+pnpm build
+pnpm test:e2e
+```
+
+## Notes
+
+- Phase 1 のデータ保存先は `localStorage`（キー: `book-reading-record.v1`）
+- E2E は Playwright（Chromium）
+- 仕様優先順位は `docs/04.e2e-cases.md > docs/03.requirements.md > docs/02.ui-layout.md`

--- a/front/README.md
+++ b/front/README.md
@@ -1,30 +1,39 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Frontend App (`front/`)
 
-## Getting Started
+Next.js 16 + TypeScript + Tailwind CSS で実装した読書記録MVPフロントエンドです。
 
-First, run the development server:
+## Requirements
+
+- Node.js 20+
+- pnpm 10+
+
+## Setup
 
 ```bash
-pnpm dev
+pnpm install
+pnpm test:e2e:install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Scripts
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- `pnpm dev`: 開発サーバー起動
+- `pnpm build`: 本番ビルド
+- `pnpm start`: 本番モード起動
+- `pnpm lint`: ESLint
+- `pnpm lint:fix`: ESLint自動修正
+- `pnpm format`: Prettier整形
+- `pnpm format:check`: Prettierチェック
+- `pnpm test:e2e`: Playwright E2E実行
+- `pnpm test:e2e:ui`: Playwright UIモード
+- `pnpm test:e2e:headed`: Headed実行
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Routes
 
-## Learn More
+- `/`: ダッシュボード
+- `/books/new`: 書籍登録
+- `/books/[id]`: 書籍詳細・進捗記録
+- `/stats`: 統計レポート
 
-To learn more about Next.js, take a look at the following resources:
+## Data Persistence
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- localStorage key: `book-reading-record.v1`


### PR DESCRIPTION
## 概要
本PRは、ドキュメント整備を2軸で実施します。

1. `README` の実運用化（root/front）
2. 実装ドキュメントの責務分離（タスクルールとタスク一覧の分割）

## 背景
- READMEが初見ユーザー向けに不足（rootは空、frontはテンプレートのまま）
- `docs/10` に「ルール」と「タスク実績」が混在し、参照時に意図が分かりづらい

## 変更内容
### 1. READMEの更新
- `README.md`
  - プロジェクト構成、MVP機能、開発/検証手順を明記
- `front/README.md`
  - セットアップ、scripts、routes、localStorageキーを実装準拠に更新

### 2. タスクドキュメントの分離
- 旧: `docs/10.implementation-tasks.md`（混在）
- 新:
  - `docs/10.task-rules.md`（役割・進行・レビュー・運用ルール）
  - `docs/11.implementation-tasks.md`（タスク一覧・実績ステータス）
- `docs/03.requirements.md` の参照マップを新ファイルに更新

## 影響範囲
- ドキュメントのみ
- 実装コード・アプリ挙動への変更なし

## 検証
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test:e2e`（18/18 pass を確認済み）

## レビュー観点
- READMEの手順だけで初回セットアップ〜検証まで再現できるか
- `docs/10` と `docs/11` の責務分離が明確か
- `docs/03` の参照リンクが新構成に一致しているか
