### PR TITLE
fix: サイドバー下部のMVP固定文言を削除

### DIFF
--- a/front/src/components/organic-shell.tsx
+++ b/front/src/components/organic-shell.tsx
@@ -76,8 +76,7 @@ export const OrganicShell = ({
         </nav>
 
         <div className="mt-7 rounded-[28px] border border-[color:var(--border)] bg-white/70 p-4 text-xs text-[color:var(--foreground)]/72">
-          <p className="font-bold">仕様固定MVP</p>
-          <p className="mt-1">localStorage / Playwright E2E</p>
+          <p>localStorage / Playwright E2E</p>
         </div>
       </aside>
 


### PR DESCRIPTION
## 背景
ダッシュボード左サイドバー下部に表示される「仕様固定MVP」の文言を不要化したい要望がありました。

## 変更内容
- `front/src/components/organic-shell.tsx` の下部カードを調整
- 「仕様固定MVP」の見出しテキストを削除
- 補足行「localStorage / Playwright E2E」はそのまま表示

## 影響範囲
- 画面表示のみ（機能・データ・API挙動への影響なし）
- 変更ファイルは `front/src/components/organic-shell.tsx` のみ

## 確認内容
- `pnpm -C front lint` 実行済み（成功）
- E2E はこの実行環境の Playwright バイナリ差異（arm64/x64不一致）で起動前失敗するため、ユーザー環境での実行結果を優先

## レビュー観点
- 左サイドバー下部から「仕様固定MVP」が消えていること
- 下部カードのレイアウト崩れがないこと
