### PR TITLE
feat: Supabase + Prisma repository flow and E2E mode stabilization

### DIFF
--- a/docs/03.requirements.md
+++ b/docs/03.requirements.md
@@ -66,5 +66,5 @@
 
 ## 6. 禁止事項
 - `base/` 配下の編集
-- Prisma schema手動変更、migrate実行
+- このリポジトリから Prisma `db push` / `migrate` を実行すること
 - 単体テスト追加（E2Eのみ）

--- a/docs/08.api-and-repository.md
+++ b/docs/08.api-and-repository.md
@@ -26,3 +26,36 @@
 - 上記I/Fを `SupabaseRepository` で実装する
 - Next.js Route Handlerの追加は任意（必要時のみ）
 - ユーザープロフィール機能が必要になるまでは単一ユーザー構成を維持する
+- 実装方針（2026-02-07）
+  - クライアントは `ApiRepository` を利用する
+  - データ更新は Next.js Route Handler 経由で `PrismaBookRecordRepository` に委譲する
+  - 運用時の切り替えは `NEXT_PUBLIC_REPOSITORY_DRIVER` で行う（`supabase` / `local`）
+
+## 6. 環境変数ファイル運用
+- 設定ファイルは `front/.env.local` を利用する
+- 共有テンプレートは `front/.env.example` に保持する
+- 想定キー
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  - `DATABASE_URL`
+  - `DIRECT_URL`
+  - `SUPABASE_SERVICE_ROLE_KEY`（サーバー用途のみ）
+
+## 7. Supabase + Prisma スキーマ同期フロー（チーム連携）
+- 前提
+  - Supabase DB / Auth は既存プロジェクトを利用する
+- このリポジトリ側の実施内容
+  - Prismaで既存プロジェクトのテーブル定義を `db pull` して同期する
+  - 実行コマンドは `cd front && pnpm prisma:pull`
+  - pull前後で `pnpm prisma:validate` / `pnpm prisma:generate` を実行する
+  - 今回プロジェクトの物理テーブル名は `BookRecord` 接頭辞を付与する
+    - `BookRecordBooks`
+    - `BookRecordProgressLogs`
+    - `BookRecordReflections`
+  - 必要な仮修正を行い、差分を別プロジェクトに依頼する
+- 別プロジェクト側の実施内容
+  - Prisma `push` で本番相当のテーブル定義へ反映する
+- 反映後の手順
+  - このリポジトリで再度 `db pull` を行い、最新定義に同期する
+- 禁止事項（このリポジトリ）
+  - `db push` / `migrate` の直接実行

--- a/docs/09.test-spec.md
+++ b/docs/09.test-spec.md
@@ -12,6 +12,8 @@
 - 実行ディレクトリ: `front/`
 - コマンド:
   - `pnpm test:e2e`
+- 実行時設定:
+  - E2Eの受け入れケース（`docs/04`）は localStorage 前提で検証するため、PlaywrightのwebServerは `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で起動する
 - 合格条件:
   - 全ケース成功（skipなし）
 

--- a/docs/10.implementation-tasks.md
+++ b/docs/10.implementation-tasks.md
@@ -61,3 +61,16 @@
 | 設計者 | TBD |
 | 実装者 | TBD |
 | レビュー者 | TBD |
+
+## 8. タスク状態（Supabase連携）
+| ID | タスク | 状態 |
+| --- | --- | --- |
+| S1 | Prismaスキーマ整備（`BookRecord*` 接頭辞、共存スキーマ） | done |
+| S2 | Next.js Route Handler + PrismaRepository 実装 | done |
+| S3 | Repository切替（`local` / `supabase`）実装 | done |
+| S4 | 画面のLocalStorage専用依存（`readRawPayload`）除去 | done |
+| S5 | E2E再整備（localStorage前提で18ケース実行） | done |
+| S6 | Supabase運用確認（実データCRUD） | done |
+
+補足:
+- 2026-02-07 に `/api/book-record/*` 経由で create/get/patch/addProgressLog/saveReflection/reread を実行し、検証データは削除済み

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,0 +1,12 @@
+# Supabase client (browser)
+NEXT_PUBLIC_SUPABASE_URL="https://your-project-ref.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key"
+NEXT_PUBLIC_REPOSITORY_DRIVER="supabase"
+
+# Supabase + Prisma (server / CLI)
+# NOTE: This repository syncs schema by pull. Do not run push here.
+DATABASE_URL="postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres?schema=public"
+DIRECT_URL="postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres?schema=public"
+
+# Optional server-side key (never expose to browser)
+SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/front/README.md
+++ b/front/README.md
@@ -14,6 +14,31 @@ pnpm install
 pnpm test:e2e:install
 ```
 
+必要に応じて環境変数ファイルを作成します。
+
+```bash
+cp .env.example .env.local
+```
+
+## Environment Variables
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_REPOSITORY_DRIVER`（`supabase` or `local`）
+- `DATABASE_URL`
+- `DIRECT_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`（サーバー用途のみ）
+
+実値は `.env.local` に設定し、`.env.example` は共有テンプレートとして管理します。
+
+## Supabase + Prisma運用（チームルール）
+
+1. このリポジトリでは、既存Supabaseプロジェクトのテーブル定義を `Prisma db pull` で同期する
+2. テーブル定義の反映（push）は別プロジェクト側で実施してもらう
+3. 別プロジェクトで反映完了後、このリポジトリで再度 `Prisma db pull` を実行する
+4. このリポジトリから `Prisma db push` / `Prisma migrate` は実行しない
+5. このプロジェクト用の物理テーブル名は `BookRecord` 接頭辞を付与する
+
 ## Scripts
 
 - `pnpm dev`: 開発サーバー起動
@@ -23,6 +48,9 @@ pnpm test:e2e:install
 - `pnpm lint:fix`: ESLint自動修正
 - `pnpm format`: Prettier整形
 - `pnpm format:check`: Prettierチェック
+- `pnpm prisma:validate`: `.env.local` を読み込んでPrismaスキーマ検証
+- `pnpm prisma:pull`: `.env.local` を読み込んでSupabase定義をpull
+- `pnpm prisma:generate`: `.env.local` を読み込んでPrisma Client生成
 - `pnpm test:e2e`: Playwright E2E実行
 - `pnpm test:e2e:ui`: Playwright UIモード
 - `pnpm test:e2e:headed`: Headed実行
@@ -36,4 +64,7 @@ pnpm test:e2e:install
 
 ## Data Persistence
 
-- localStorage key: `book-reading-record.v1`
+- `NEXT_PUBLIC_REPOSITORY_DRIVER=supabase` の場合:
+  - Prisma経由のSupabase DB（`BookRecord*` テーブル）を利用
+- `NEXT_PUBLIC_REPOSITORY_DRIVER=local` の場合:
+  - localStorage key: `book-reading-record.v1`

--- a/front/package.json
+++ b/front/package.json
@@ -11,12 +11,16 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "prisma:generate": "node scripts/prisma-with-env-local.mjs generate",
+    "prisma:pull": "node scripts/prisma-with-env-local.mjs db pull",
+    "prisma:validate": "node scripts/prisma-with-env-local.mjs validate",
     "test:e2e": "PLAYWRIGHT_BROWSERS_PATH=.playwright playwright test",
     "test:e2e:ui": "PLAYWRIGHT_BROWSERS_PATH=.playwright playwright test --ui",
     "test:e2e:headed": "PLAYWRIGHT_BROWSERS_PATH=.playwright playwright test --headed",
     "test:e2e:install": "PLAYWRIGHT_BROWSERS_PATH=.playwright playwright install chromium"
   },
   "dependencies": {
+    "@prisma/client": "^6.16.2",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"
@@ -32,6 +36,7 @@
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
+    "prisma": "^6.16.2",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -11,8 +11,12 @@ export default defineConfig({
   webServer: {
     command: "pnpm build && pnpm exec next start -p 3000",
     url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: false,
     timeout: 240_000,
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_REPOSITORY_DRIVER: "local",
+    },
   },
   projects: [
     {

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@prisma/client':
+        specifier: ^6.16.2
+        version: 6.16.2(prisma@6.16.2(typescript@5.9.3))(typescript@5.9.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -48,6 +51,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      prisma:
+        specifier: ^6.16.2
+        version: 6.16.2(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.18
@@ -422,8 +428,41 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@prisma/client@6.16.2':
+    resolution: {integrity: sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@6.16.2':
+    resolution: {integrity: sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==}
+
+  '@prisma/debug@6.16.2':
+    resolution: {integrity: sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==}
+
+  '@prisma/engines-version@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43':
+    resolution: {integrity: sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==}
+
+  '@prisma/engines@6.16.2':
+    resolution: {integrity: sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==}
+
+  '@prisma/fetch-engine@6.16.2':
+    resolution: {integrity: sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==}
+
+  '@prisma/get-platform@6.16.2':
+    resolution: {integrity: sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -793,6 +832,14 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -816,6 +863,16 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.0:
+    resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -828,6 +885,13 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -874,6 +938,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -881,6 +949,12 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -890,15 +964,26 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  effect@3.16.12:
+    resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
@@ -1066,6 +1151,13 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1151,6 +1243,10 @@ packages:
 
   get-tsconfig@4.13.5:
     resolution: {integrity: sha512-v4/4xAEpBRp6SvCkWhnGCaLkJf9IwWzrsygJPxD/+p2/xPE3C5m2fA9FD0Ry9tG+Rqqq3gBzHSl6y1/T9V/tMQ==}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1543,8 +1639,16 @@ packages:
       sass:
         optional: true
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  nypm@0.6.5:
+    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1578,6 +1682,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1609,6 +1716,12 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1619,6 +1732,9 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   playwright-core@1.58.1:
     resolution: {integrity: sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==}
@@ -1651,6 +1767,16 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prisma@6.16.2:
+    resolution: {integrity: sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1658,8 +1784,14 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -1672,6 +1804,10 @@ packages:
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1837,6 +1973,10 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -2298,7 +2438,44 @@ snapshots:
     dependencies:
       playwright: 1.58.1
 
+  '@prisma/client@6.16.2(prisma@6.16.2(typescript@5.9.3))(typescript@5.9.3)':
+    optionalDependencies:
+      prisma: 6.16.2(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@prisma/config@6.16.2':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.16.12
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.16.2': {}
+
+  '@prisma/engines-version@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43': {}
+
+  '@prisma/engines@6.16.2':
+    dependencies:
+      '@prisma/debug': 6.16.2
+      '@prisma/engines-version': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
+      '@prisma/fetch-engine': 6.16.2
+      '@prisma/get-platform': 6.16.2
+
+  '@prisma/fetch-engine@6.16.2':
+    dependencies:
+      '@prisma/debug': 6.16.2
+      '@prisma/engines-version': 6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43
+      '@prisma/get-platform': 6.16.2
+
+  '@prisma/get-platform@6.16.2':
+    dependencies:
+      '@prisma/debug': 6.16.2
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2675,6 +2852,21 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.4
+      defu: 6.1.4
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2701,6 +2893,16 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.0: {}
+
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
@@ -2710,6 +2912,10 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2751,6 +2957,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge-ts@7.1.5: {}
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -2763,11 +2971,17 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.4: {}
+
+  destr@2.0.5: {}
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2775,9 +2989,16 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  effect@3.16.12:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.286: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@2.0.0: {}
 
   enhanced-resolve@5.19.0:
     dependencies:
@@ -2894,8 +3115,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -2921,7 +3142,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -2932,22 +3153,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -2958,7 +3179,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3096,6 +3317,12 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3189,6 +3416,15 @@ snapshots:
   get-tsconfig@4.13.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.5
+      pathe: 2.0.3
 
   glob-parent@5.1.2:
     dependencies:
@@ -3545,7 +3781,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-fetch-native@1.6.7: {}
+
   node-releases@2.0.27: {}
+
+  nypm@0.6.5:
+    dependencies:
+      citty: 0.2.0
+      pathe: 2.0.3
+      tinyexec: 1.0.2
 
   object-assign@4.1.1: {}
 
@@ -3589,6 +3833,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  ohash@2.0.11: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3622,11 +3868,21 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
 
   playwright-core@1.58.1: {}
 
@@ -3654,6 +3910,15 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  prisma@6.16.2(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 6.16.2
+      '@prisma/engines': 6.16.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - magicast
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3662,7 +3927,14 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@6.1.0: {}
+
   queue-microtask@1.2.3: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -3672,6 +3944,8 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.3: {}
+
+  readdirp@4.1.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3907,6 +4181,8 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:

--- a/front/prisma/schema.prisma
+++ b/front/prisma/schema.prisma
@@ -1,0 +1,190 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model ExerciseCardio {
+  id             String         @id
+  recordId       String         @unique
+  type           String
+  minutes        Float
+  distance       Float
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime
+  ExerciseRecord ExerciseRecord @relation(fields: [recordId], references: [id], onDelete: Cascade)
+
+  @@index([recordId])
+}
+
+model ExerciseMaster {
+  id        String   @id
+  type      String
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime
+
+  @@unique([type, name])
+  @@index([name])
+  @@index([type])
+}
+
+model ExerciseProfile {
+  id        String   @id
+  weightKg  Float
+  createdAt DateTime @default(now())
+  updatedAt DateTime
+}
+
+model ExerciseRecord {
+  id              String            @id
+  date            DateTime          @unique
+  memo            String?
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime
+  ExerciseCardio  ExerciseCardio?
+  ExerciseWorkout ExerciseWorkout[]
+
+  @@index([createdAt])
+  @@index([date])
+}
+
+model ExerciseWorkout {
+  id             String         @id
+  recordId       String
+  part           String
+  name           String
+  sets           Float
+  reps           Float
+  weight         Float
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime
+  ExerciseRecord ExerciseRecord @relation(fields: [recordId], references: [id], onDelete: Cascade)
+
+  @@index([recordId])
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model Report {
+  id               String             @id
+  title            String
+  summary          String?
+  content          String
+  category         String
+  author           String
+  publishDate      DateTime?
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime
+  ReportTagMapping ReportTagMapping[]
+
+  @@index([category])
+  @@index([createdAt])
+  @@index([publishDate])
+}
+
+model ReportTag {
+  id               String             @id
+  name             String             @unique
+  createdAt        DateTime           @default(now())
+  ReportTagMapping ReportTagMapping[]
+
+  @@index([name])
+}
+
+model ReportTagMapping {
+  id          String    @id
+  reportId    String
+  reportTagId String
+  createdAt   DateTime  @default(now())
+  Report      Report    @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  ReportTag   ReportTag @relation(fields: [reportTagId], references: [id], onDelete: Cascade)
+
+  @@unique([reportId, reportTagId])
+  @@index([reportId])
+  @@index([reportTagId])
+}
+
+model VideoEntry {
+  id           String    @id
+  youtubeUrl   String
+  title        String
+  thumbnailUrl String
+  tags         String[]
+  category     String
+  goodPoints   String
+  memo         String
+  rating       Int
+  publishDate  DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime
+
+  @@index([createdAt])
+  @@index([publishDate])
+  @@index([rating])
+}
+
+model BookRecordBook {
+  id           String                  @id @default(uuid()) @db.Uuid
+  title        String                  @db.VarChar(200)
+  author       String                  @db.VarChar(120)
+  genre        String?                 @db.VarChar(80)
+  format       BookRecordFormat
+  totalPages   Int                     @map("total_pages")
+  currentPage  Int                     @default(0) @map("current_page")
+  tags         String[]                @default([])
+  status       BookRecordStatus        @default(not_started)
+  createdAt    DateTime                @default(now()) @map("created_at")
+  updatedAt    DateTime                @updatedAt @map("updated_at")
+  completedAt  DateTime?               @map("completed_at")
+  progressLogs BookRecordProgressLog[]
+  reflection   BookRecordReflection?
+
+  @@index([title])
+  @@index([author])
+  @@index([status, updatedAt(sort: Desc)])
+  @@index([updatedAt(sort: Desc), createdAt(sort: Desc)])
+  @@map("BookRecordBooks")
+}
+
+model BookRecordProgressLog {
+  id       String           @id @default(uuid()) @db.Uuid
+  bookId   String           @map("book_id") @db.Uuid
+  page     Int
+  memo     String?          @db.VarChar(5000)
+  status   BookRecordStatus
+  loggedAt DateTime         @default(now()) @map("logged_at")
+  book     BookRecordBook   @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  @@index([bookId, loggedAt(sort: Desc)])
+  @@index([loggedAt(sort: Desc)])
+  @@map("BookRecordProgressLogs")
+}
+
+model BookRecordReflection {
+  id        String         @id @default(uuid()) @db.Uuid
+  bookId    String         @unique @map("book_id") @db.Uuid
+  learning  String         @default("") @db.VarChar(5000)
+  action    String         @default("") @db.VarChar(5000)
+  quote     String         @default("") @db.VarChar(5000)
+  createdAt DateTime       @default(now()) @map("created_at")
+  updatedAt DateTime       @updatedAt @map("updated_at")
+  book      BookRecordBook @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  @@map("BookRecordReflections")
+}
+
+enum BookRecordStatus {
+  not_started
+  reading
+  paused
+  completed
+}
+
+enum BookRecordFormat {
+  paper
+  ebook
+  audio
+}

--- a/front/scripts/prisma-with-env-local.mjs
+++ b/front/scripts/prisma-with-env-local.mjs
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const ENV_FILES = [".env.local", ".env"];
+
+const parseEnvFile = (content) => {
+  const entries = {};
+  const lines = content.split(/\r?\n/);
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const withoutExport = line.startsWith("export ") ? line.slice(7).trim() : line;
+    const separator = withoutExport.indexOf("=");
+    if (separator < 1) {
+      continue;
+    }
+
+    const key = withoutExport.slice(0, separator).trim();
+    let value = withoutExport.slice(separator + 1).trim();
+
+    const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
+    const isSingleQuoted = value.startsWith("'") && value.endsWith("'");
+    if (isDoubleQuoted || isSingleQuoted) {
+      value = value.slice(1, -1);
+    }
+
+    entries[key] = value;
+  }
+
+  return entries;
+};
+
+const loadEnv = () => {
+  const loaded = {};
+
+  for (const path of ENV_FILES) {
+    if (!existsSync(path)) {
+      continue;
+    }
+
+    const parsed = parseEnvFile(readFileSync(path, "utf8"));
+    Object.assign(loaded, parsed);
+  }
+
+  return loaded;
+};
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error("Usage: node scripts/prisma-with-env-local.mjs <prisma-args...>");
+  process.exit(1);
+}
+
+const envFromFiles = loadEnv();
+const mergedEnv = { ...envFromFiles, ...process.env };
+const result = spawnSync("prisma", args, {
+  stdio: "inherit",
+  env: mergedEnv,
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/front/src/app/api/book-record/books/[id]/progress-logs/route.ts
+++ b/front/src/app/api/book-record/books/[id]/progress-logs/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CreateProgressLogInput } from "@/lib/types";
+import {
+  isRepositoryError,
+  PrismaBookRecordRepository,
+} from "@/lib/server/prisma-book-record-repository";
+
+const repository = new PrismaBookRecordRepository();
+
+const BOOK_STATUS_VALUES = ["not_started", "reading", "paused", "completed"] as const;
+
+const parseCreateProgressInput = (body: unknown): CreateProgressLogInput | null => {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const candidate = body as Record<string, unknown>;
+  const status = candidate.status;
+
+  if (
+    typeof candidate.page !== "number" ||
+    typeof candidate.memo !== "string" ||
+    typeof status !== "string" ||
+    !BOOK_STATUS_VALUES.includes(status as (typeof BOOK_STATUS_VALUES)[number])
+  ) {
+    return null;
+  }
+
+  const typedStatus = status as (typeof BOOK_STATUS_VALUES)[number];
+
+  const input: CreateProgressLogInput = {
+    page: candidate.page,
+    memo: candidate.memo,
+    status: typedStatus,
+  };
+
+  if (typeof candidate.loggedAt === "string") {
+    input.loggedAt = candidate.loggedAt;
+  }
+
+  return input;
+};
+
+const errorResponse = (message: string, status: number): NextResponse => {
+  return NextResponse.json({ message }, { status });
+};
+
+type Params = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(_request: NextRequest, context: Params) {
+  try {
+    const { id } = await context.params;
+    const logs = await repository.listProgressLogs(id);
+    return NextResponse.json({ logs });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("進捗履歴の取得に失敗しました。", 500);
+  }
+}
+
+export async function POST(request: NextRequest, context: Params) {
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const input = parseCreateProgressInput(body);
+
+    if (!input) {
+      return errorResponse("進捗登録リクエストが不正です。", 400);
+    }
+
+    const payload = await repository.addProgressLog(id, input);
+    return NextResponse.json(payload, { status: 201 });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("進捗の登録に失敗しました。", 500);
+  }
+}

--- a/front/src/app/api/book-record/books/[id]/reflection/route.ts
+++ b/front/src/app/api/book-record/books/[id]/reflection/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ReflectionInput } from "@/lib/types";
+import {
+  isRepositoryError,
+  PrismaBookRecordRepository,
+} from "@/lib/server/prisma-book-record-repository";
+
+const repository = new PrismaBookRecordRepository();
+
+const parseReflectionInput = (body: unknown): ReflectionInput | null => {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const candidate = body as Record<string, unknown>;
+
+  if (
+    typeof candidate.learning !== "string" ||
+    typeof candidate.action !== "string" ||
+    typeof candidate.quote !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    learning: candidate.learning,
+    action: candidate.action,
+    quote: candidate.quote,
+  };
+};
+
+const errorResponse = (message: string, status: number): NextResponse => {
+  return NextResponse.json({ message }, { status });
+};
+
+type Params = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(request: NextRequest, context: Params) {
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const input = parseReflectionInput(body);
+
+    if (!input) {
+      return errorResponse("感想保存リクエストが不正です。", 400);
+    }
+
+    const book = await repository.saveReflection(id, input);
+    return NextResponse.json({ book });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("感想の保存に失敗しました。", 500);
+  }
+}

--- a/front/src/app/api/book-record/books/[id]/route.ts
+++ b/front/src/app/api/book-record/books/[id]/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { UpdateBookInput } from "@/lib/types";
+import {
+  isRepositoryError,
+  PrismaBookRecordRepository,
+} from "@/lib/server/prisma-book-record-repository";
+
+const repository = new PrismaBookRecordRepository();
+
+const BOOK_STATUS_VALUES = ["not_started", "reading", "paused", "completed"] as const;
+const BOOK_FORMAT_VALUES = ["paper", "ebook", "audio"] as const;
+
+const parseUpdateBookInput = (body: unknown): UpdateBookInput | null => {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const candidate = body as Record<string, unknown>;
+  const patch: UpdateBookInput = {};
+
+  if (typeof candidate.title === "string") {
+    patch.title = candidate.title;
+  }
+
+  if (typeof candidate.author === "string") {
+    patch.author = candidate.author;
+  }
+
+  if (typeof candidate.genre === "string") {
+    patch.genre = candidate.genre;
+  }
+
+  if (
+    typeof candidate.format === "string" &&
+    BOOK_FORMAT_VALUES.includes(candidate.format as (typeof BOOK_FORMAT_VALUES)[number])
+  ) {
+    patch.format = candidate.format as (typeof BOOK_FORMAT_VALUES)[number];
+  }
+
+  if (typeof candidate.totalPages === "number") {
+    patch.totalPages = candidate.totalPages;
+  }
+
+  if (typeof candidate.currentPage === "number") {
+    patch.currentPage = candidate.currentPage;
+  }
+
+  if (Array.isArray(candidate.tags)) {
+    patch.tags = candidate.tags.filter((value): value is string => typeof value === "string");
+  }
+
+  if (
+    typeof candidate.status === "string" &&
+    BOOK_STATUS_VALUES.includes(candidate.status as (typeof BOOK_STATUS_VALUES)[number])
+  ) {
+    patch.status = candidate.status as (typeof BOOK_STATUS_VALUES)[number];
+  }
+
+  if (typeof candidate.completedAt === "string") {
+    patch.completedAt = candidate.completedAt;
+  }
+
+  return patch;
+};
+
+const errorResponse = (message: string, status: number): NextResponse => {
+  return NextResponse.json({ message }, { status });
+};
+
+type Params = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(_request: NextRequest, context: Params) {
+  try {
+    const { id } = await context.params;
+    const book = await repository.getBook(id);
+
+    if (!book) {
+      return errorResponse("対象の書籍が見つかりません。", 404);
+    }
+
+    return NextResponse.json({ book });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("書籍の取得に失敗しました。", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: Params) {
+  try {
+    const { id } = await context.params;
+    const body = await request.json();
+    const patch = parseUpdateBookInput(body);
+
+    if (!patch) {
+      return errorResponse("書籍更新リクエストが不正です。", 400);
+    }
+
+    const book = await repository.updateBook(id, patch);
+    return NextResponse.json({ book });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("書籍の更新に失敗しました。", 500);
+  }
+}

--- a/front/src/app/api/book-record/books/route.ts
+++ b/front/src/app/api/book-record/books/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CreateBookInput } from "@/lib/types";
+import {
+  isRepositoryError,
+  PrismaBookRecordRepository,
+} from "@/lib/server/prisma-book-record-repository";
+
+const repository = new PrismaBookRecordRepository();
+
+const BOOK_STATUS_VALUES = ["not_started", "reading", "paused"] as const;
+const BOOK_FORMAT_VALUES = ["paper", "ebook", "audio"] as const;
+
+const parseCreateBookInput = (body: unknown): CreateBookInput | null => {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const candidate = body as Record<string, unknown>;
+  const status = candidate.status;
+  const format = candidate.format;
+
+  if (
+    typeof candidate.title !== "string" ||
+    typeof candidate.author !== "string" ||
+    typeof candidate.genre !== "string" ||
+    typeof candidate.totalPages !== "number" ||
+    !Array.isArray(candidate.tags) ||
+    !BOOK_STATUS_VALUES.includes(status as (typeof BOOK_STATUS_VALUES)[number]) ||
+    !BOOK_FORMAT_VALUES.includes(format as (typeof BOOK_FORMAT_VALUES)[number])
+  ) {
+    return null;
+  }
+
+  const tags = candidate.tags.filter((value): value is string => typeof value === "string");
+  const typedStatus = status as (typeof BOOK_STATUS_VALUES)[number];
+  const typedFormat = format as (typeof BOOK_FORMAT_VALUES)[number];
+
+  return {
+    title: candidate.title,
+    author: candidate.author,
+    genre: candidate.genre,
+    format: typedFormat,
+    totalPages: candidate.totalPages,
+    tags,
+    status: typedStatus,
+  };
+};
+
+const errorResponse = (message: string, status: number): NextResponse => {
+  return NextResponse.json({ message }, { status });
+};
+
+export async function GET() {
+  try {
+    const books = await repository.listBooks();
+    return NextResponse.json({ books });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("書籍一覧の取得に失敗しました。", 500);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const input = parseCreateBookInput(body);
+
+    if (!input) {
+      return errorResponse("書籍作成リクエストが不正です。", 400);
+    }
+
+    const book = await repository.createBook(input);
+    return NextResponse.json({ book }, { status: 201 });
+  } catch (error) {
+    if (isRepositoryError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
+    return errorResponse("書籍の作成に失敗しました。", 500);
+  }
+}

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -6,7 +6,7 @@ import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS, STATUS_ORDER } from "@/lib/constants";
 import { computeWeeklySummary, consumeRecoveryNotice, reflectionIsMissing } from "@/lib/helpers";
 import { repository } from "@/lib/repository-instance";
-import { Book, BookStatus } from "@/lib/types";
+import { Book, BookStatus, ProgressLog } from "@/lib/types";
 
 const SECTION_CONFIG: Array<{ status: BookStatus; testId: string }> = [
   { status: "not_started", testId: "section-not-started" },
@@ -82,7 +82,7 @@ const Section = ({ title, testId, books }: { title: string; testId: string; book
 
 export default function DashboardPage() {
   const [books, setBooks] = useState<Book[]>([]);
-  const [logs, setLogs] = useState(repository.readRawPayload().progressLogs);
+  const [logs, setLogs] = useState<ProgressLog[]>([]);
   const [query, setQuery] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [recoveryNotice, setRecoveryNotice] = useState<string | null>(null);
@@ -91,8 +91,11 @@ export default function DashboardPage() {
     const load = async () => {
       try {
         const loadedBooks = await repository.listBooks();
+        const logsByBook = await Promise.all(
+          loadedBooks.map(async (book) => repository.listProgressLogs(book.id))
+        );
         setBooks(loadedBooks);
-        setLogs(repository.readRawPayload().progressLogs);
+        setLogs(logsByBook.flat());
         setRecoveryNotice(consumeRecoveryNotice());
       } catch (error) {
         const message = error instanceof Error ? error.message : "データの読み込みに失敗しました。";

--- a/front/src/app/stats/page.tsx
+++ b/front/src/app/stats/page.tsx
@@ -5,21 +5,24 @@ import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS, STATUS_ORDER } from "@/lib/constants";
 import { computeWeeklySummary } from "@/lib/helpers";
 import { repository } from "@/lib/repository-instance";
-import { Book } from "@/lib/types";
+import { Book, ProgressLog } from "@/lib/types";
 
 const toPercent = (value: number): number => Math.round(value * 1000) / 10;
 
 export default function StatsPage() {
   const [books, setBooks] = useState<Book[]>([]);
-  const [logs, setLogs] = useState(repository.readRawPayload().progressLogs);
+  const [logs, setLogs] = useState<ProgressLog[]>([]);
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
     const load = async () => {
       try {
         const loadedBooks = await repository.listBooks();
+        const logsByBook = await Promise.all(
+          loadedBooks.map(async (book) => repository.listProgressLogs(book.id))
+        );
         setBooks(loadedBooks);
-        setLogs(repository.readRawPayload().progressLogs);
+        setLogs(logsByBook.flat());
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "統計データの読み込みに失敗しました。";

--- a/front/src/lib/api-repository.ts
+++ b/front/src/lib/api-repository.ts
@@ -1,0 +1,132 @@
+import { BookRepository } from "./repository";
+import {
+  Book,
+  CreateBookInput,
+  CreateProgressLogInput,
+  ProgressLog,
+  ReflectionInput,
+  UpdateBookInput,
+} from "./types";
+
+type ApiError = {
+  message?: string;
+};
+
+const readErrorMessage = async (response: Response): Promise<string> => {
+  try {
+    const data = (await response.json()) as ApiError;
+    if (typeof data.message === "string" && data.message.length > 0) {
+      return data.message;
+    }
+  } catch {
+    // no-op
+  }
+
+  return "データ操作に失敗しました。";
+};
+
+export class ApiRepository implements BookRepository {
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(path, {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(await readErrorMessage(response));
+    }
+
+    return (await response.json()) as T;
+  }
+
+  async listBooks(): Promise<Book[]> {
+    const data = await this.request<{ books: Book[] }>("/api/book-record/books");
+    return data.books;
+  }
+
+  async getBook(bookId: string): Promise<Book | null> {
+    const response = await fetch(`/api/book-record/books/${bookId}`);
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(await readErrorMessage(response));
+    }
+
+    const data = (await response.json()) as { book: Book };
+    return data.book;
+  }
+
+  async listProgressLogs(bookId: string): Promise<ProgressLog[]> {
+    const data = await this.request<{ logs: ProgressLog[] }>(
+      `/api/book-record/books/${bookId}/progress-logs`
+    );
+    return data.logs;
+  }
+
+  async createBook(input: CreateBookInput): Promise<Book> {
+    const data = await this.request<{ book: Book }>("/api/book-record/books", {
+      method: "POST",
+      body: JSON.stringify({
+        ...input,
+        genre: input.genre ?? "",
+      }),
+    });
+
+    return data.book;
+  }
+
+  async updateBook(bookId: string, patch: UpdateBookInput): Promise<Book> {
+    const data = await this.request<{ book: Book }>(`/api/book-record/books/${bookId}`, {
+      method: "PATCH",
+      body: JSON.stringify(patch),
+    });
+
+    return data.book;
+  }
+
+  async addProgressLog(
+    bookId: string,
+    input: CreateProgressLogInput
+  ): Promise<{ book: Book; log: ProgressLog }> {
+    return this.request<{ book: Book; log: ProgressLog }>(
+      `/api/book-record/books/${bookId}/progress-logs`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          page: input.page,
+          memo: input.memo ?? "",
+          status: input.status,
+          loggedAt: input.loggedAt,
+        }),
+      }
+    );
+  }
+
+  async saveReflection(bookId: string, input: ReflectionInput): Promise<Book> {
+    const data = await this.request<{ book: Book }>(`/api/book-record/books/${bookId}/reflection`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+
+    return data.book;
+  }
+
+  async searchBooks(query: string): Promise<Book[]> {
+    const normalized = query.trim().toLocaleLowerCase();
+    const books = await this.listBooks();
+
+    if (!normalized) {
+      return books;
+    }
+
+    return books.filter((book) => {
+      const target = [book.title, book.author, ...(book.tags ?? [])].join(" ").toLocaleLowerCase();
+      return target.includes(normalized);
+    });
+  }
+}

--- a/front/src/lib/repository-instance.ts
+++ b/front/src/lib/repository-instance.ts
@@ -1,3 +1,25 @@
+import { ApiRepository } from "./api-repository";
 import { LocalStorageRepository } from "./local-storage-repository";
+import { BookRepository } from "./repository";
 
-export const repository = new LocalStorageRepository();
+const decideDriver = (): "local" | "supabase" => {
+  const forcedDriver = process.env.NEXT_PUBLIC_REPOSITORY_DRIVER;
+  if (forcedDriver === "local") {
+    return "local";
+  }
+
+  if (forcedDriver === "supabase") {
+    return "supabase";
+  }
+
+  const hasSupabaseConfig = Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
+
+  return hasSupabaseConfig ? "supabase" : "local";
+};
+
+const driver = decideDriver();
+
+export const repository: BookRepository =
+  driver === "supabase" ? new ApiRepository() : new LocalStorageRepository();

--- a/front/src/lib/server/prisma-book-record-repository.ts
+++ b/front/src/lib/server/prisma-book-record-repository.ts
@@ -1,0 +1,515 @@
+import "server-only";
+
+import { BookRecordFormat, BookRecordStatus } from "@prisma/client";
+import type { BookRecordBook, BookRecordProgressLog, BookRecordReflection } from "@prisma/client";
+import { BookRepository } from "@/lib/repository";
+import {
+  Book,
+  BookFormat,
+  BookStatus,
+  CreateBookInput,
+  CreateProgressLogInput,
+  ProgressLog,
+  Reflection,
+  ReflectionInput,
+  UpdateBookInput,
+} from "@/lib/types";
+import { validateReflection } from "@/lib/validation";
+import { prisma } from "./prisma-client";
+
+const BOOK_STATUS_VALUES: BookStatus[] = ["not_started", "reading", "paused", "completed"];
+const BOOK_FORMAT_VALUES: BookFormat[] = ["paper", "ebook", "audio"];
+
+const isIntegerInRange = (value: number, min: number, max: number): boolean => {
+  return Number.isInteger(value) && value >= min && value <= max;
+};
+
+const isBookStatus = (value: string): value is BookStatus => {
+  return BOOK_STATUS_VALUES.includes(value as BookStatus);
+};
+
+const isBookFormat = (value: string): value is BookFormat => {
+  return BOOK_FORMAT_VALUES.includes(value as BookFormat);
+};
+
+const normalizeTags = (tags: string[]): string[] => {
+  return tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+};
+
+const firstValidationMessage = (errors: Record<string, string>): string => {
+  return Object.values(errors)[0] ?? "入力内容が不正です。";
+};
+
+const toReflection = (row: BookRecordReflection | null): Reflection | undefined => {
+  if (!row) {
+    return undefined;
+  }
+
+  return {
+    learning: row.learning,
+    action: row.action,
+    quote: row.quote,
+    createdAt: row.createdAt.toISOString(),
+  };
+};
+
+const toBook = (
+  row: BookRecordBook & {
+    reflection: BookRecordReflection | null;
+  }
+): Book => {
+  return {
+    id: row.id,
+    title: row.title,
+    author: row.author,
+    genre: row.genre ?? undefined,
+    format: row.format as BookFormat,
+    totalPages: row.totalPages,
+    currentPage: row.currentPage,
+    tags: row.tags,
+    status: row.status as BookStatus,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    completedAt: row.completedAt?.toISOString(),
+    reflection: toReflection(row.reflection),
+  };
+};
+
+const toProgressLog = (row: BookRecordProgressLog): ProgressLog => {
+  return {
+    id: row.id,
+    bookId: row.bookId,
+    page: row.page,
+    memo: row.memo ?? undefined,
+    status: row.status as BookStatus,
+    loggedAt: row.loggedAt.toISOString(),
+  };
+};
+
+type BookDraft = {
+  title: string;
+  author: string;
+  genre?: string;
+  format: BookFormat;
+  totalPages: number;
+  currentPage: number;
+  tags: string[];
+  status: BookStatus;
+};
+
+const validateBookDraft = (
+  input: BookDraft,
+  options: {
+    allowCompletedStatus: boolean;
+  }
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+
+  if (input.title.trim().length < 1 || input.title.trim().length > 200) {
+    errors.title = "タイトルは1〜200文字で入力してください。";
+  }
+
+  if (input.author.trim().length < 1 || input.author.trim().length > 120) {
+    errors.author = "著者は1〜120文字で入力してください。";
+  }
+
+  if ((input.genre ?? "").trim().length > 80) {
+    errors.genre = "ジャンルは80文字以内で入力してください。";
+  }
+
+  if (!isIntegerInRange(input.totalPages, 1, 100000)) {
+    errors.totalPages = "総ページ数は1〜100000の整数で入力してください。";
+  }
+
+  if (!isIntegerInRange(input.currentPage, 0, 100000)) {
+    errors.currentPage = "現在ページは0〜100000の整数で入力してください。";
+  }
+
+  if (input.tags.length > 10) {
+    errors.tags = "タグは最大10件までです。";
+  } else if (input.tags.some((tag) => tag.length < 1 || tag.length > 30)) {
+    errors.tags = "タグは1〜30文字で入力してください。";
+  }
+
+  if (!isBookFormat(input.format)) {
+    errors.format = "読書形式が不正です。";
+  }
+
+  if (!isBookStatus(input.status)) {
+    errors.status = "ステータスが不正です。";
+  } else if (!options.allowCompletedStatus && input.status === "completed") {
+    errors.status = "初期ステータスに完読は指定できません。";
+  }
+
+  return errors;
+};
+
+const validateProgressDraft = (input: {
+  page: number;
+  totalPages: number;
+  status: BookStatus;
+  memo: string;
+}): Record<string, string> => {
+  const errors: Record<string, string> = {};
+
+  if (!isIntegerInRange(input.page, 0, 100000)) {
+    errors.page = "到達ページは0〜100000の整数で入力してください。";
+  }
+
+  if (input.memo.length > 5000) {
+    errors.memo = "メモは5000文字以内で入力してください。";
+  }
+
+  if (!isBookStatus(input.status)) {
+    errors.status = "ステータスが不正です。";
+  }
+
+  if (input.status === "completed" && input.page < input.totalPages) {
+    errors.status = "完読にするには到達ページを総ページ以上にしてください。";
+  }
+
+  return errors;
+};
+
+const parseLoggedAt = (loggedAt: string | undefined): Date => {
+  if (!loggedAt) {
+    return new Date();
+  }
+
+  const parsed = new Date(loggedAt);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new RepositoryValidationError("記録日が不正です。");
+  }
+
+  return parsed;
+};
+
+export class RepositoryValidationError extends Error {
+  readonly statusCode = 400;
+}
+
+export class RepositoryNotFoundError extends Error {
+  readonly statusCode = 404;
+}
+
+export const isRepositoryError = (
+  value: unknown
+): value is RepositoryValidationError | RepositoryNotFoundError => {
+  return (
+    value instanceof RepositoryValidationError ||
+    value instanceof RepositoryNotFoundError
+  );
+};
+
+export class PrismaBookRecordRepository implements BookRepository {
+  async listBooks(): Promise<Book[]> {
+    const books = await prisma.bookRecordBook.findMany({
+      include: {
+        reflection: true,
+      },
+      orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }, { id: "asc" }],
+    });
+
+    return books.map((book) => toBook(book));
+  }
+
+  async getBook(bookId: string): Promise<Book | null> {
+    const book = await prisma.bookRecordBook.findUnique({
+      where: { id: bookId },
+      include: {
+        reflection: true,
+      },
+    });
+
+    return book ? toBook(book) : null;
+  }
+
+  async listProgressLogs(bookId: string): Promise<ProgressLog[]> {
+    const logs = await prisma.bookRecordProgressLog.findMany({
+      where: {
+        bookId,
+      },
+      orderBy: [{ loggedAt: "desc" }, { id: "asc" }],
+    });
+
+    return logs.map((log) => toProgressLog(log));
+  }
+
+  async createBook(input: CreateBookInput): Promise<Book> {
+    const draft: BookDraft = {
+      title: input.title,
+      author: input.author,
+      genre: input.genre,
+      format: input.format,
+      totalPages: input.totalPages,
+      currentPage: 0,
+      tags: normalizeTags(input.tags),
+      status: input.status,
+    };
+
+    const validationErrors = validateBookDraft(draft, { allowCompletedStatus: false });
+    if (Object.keys(validationErrors).length > 0) {
+      throw new RepositoryValidationError(firstValidationMessage(validationErrors));
+    }
+
+    const created = await prisma.bookRecordBook.create({
+      data: {
+        title: draft.title.trim(),
+        author: draft.author.trim(),
+        genre: draft.genre?.trim() ? draft.genre.trim() : null,
+        format: draft.format as BookRecordFormat,
+        totalPages: draft.totalPages,
+        currentPage: 0,
+        tags: draft.tags,
+        status: draft.status as BookRecordStatus,
+        completedAt: null,
+      },
+      include: {
+        reflection: true,
+      },
+    });
+
+    return toBook(created);
+  }
+
+  async updateBook(bookId: string, patch: UpdateBookInput): Promise<Book> {
+    const source = await prisma.bookRecordBook.findUnique({
+      where: { id: bookId },
+      include: {
+        reflection: true,
+      },
+    });
+
+    if (!source) {
+      throw new RepositoryNotFoundError("対象の書籍が見つかりません。");
+    }
+
+    const merged: BookDraft = {
+      title: patch.title ?? source.title,
+      author: patch.author ?? source.author,
+      genre: patch.genre ?? source.genre ?? undefined,
+      format: (patch.format ?? source.format) as BookFormat,
+      totalPages: patch.totalPages ?? source.totalPages,
+      currentPage: patch.currentPage ?? source.currentPage,
+      tags: normalizeTags(patch.tags ?? source.tags),
+      status: (patch.status ?? source.status) as BookStatus,
+    };
+
+    const validationErrors = validateBookDraft(merged, { allowCompletedStatus: true });
+    if (Object.keys(validationErrors).length > 0) {
+      throw new RepositoryValidationError(firstValidationMessage(validationErrors));
+    }
+
+    let status = merged.status;
+    if (merged.currentPage >= merged.totalPages) {
+      status = "completed";
+    }
+
+    if (status === "completed" && merged.currentPage < merged.totalPages) {
+      throw new RepositoryValidationError(
+        "完読にするには到達ページを総ページ以上にしてください。"
+      );
+    }
+
+    const updated = await prisma.bookRecordBook.update({
+      where: { id: bookId },
+      data: {
+        title: merged.title.trim(),
+        author: merged.author.trim(),
+        genre: merged.genre?.trim() ? merged.genre.trim() : null,
+        format: merged.format as BookRecordFormat,
+        totalPages: merged.totalPages,
+        currentPage: merged.currentPage,
+        tags: merged.tags,
+        status: status as BookRecordStatus,
+        completedAt: status === "completed" ? source.completedAt ?? new Date() : null,
+      },
+      include: {
+        reflection: true,
+      },
+    });
+
+    if (patch.reflection) {
+      const reflectionErrors = validateReflection(patch.reflection);
+      if (Object.keys(reflectionErrors).length > 0) {
+        throw new RepositoryValidationError(firstValidationMessage(reflectionErrors));
+      }
+
+      await prisma.bookRecordReflection.upsert({
+        where: {
+          bookId,
+        },
+        create: {
+          bookId,
+          learning: patch.reflection.learning,
+          action: patch.reflection.action,
+          quote: patch.reflection.quote,
+          createdAt: new Date(),
+        },
+        update: {
+          learning: patch.reflection.learning,
+          action: patch.reflection.action,
+          quote: patch.reflection.quote,
+        },
+      });
+    }
+
+    if (!patch.reflection) {
+      return toBook(updated);
+    }
+
+    const refreshed = await prisma.bookRecordBook.findUnique({
+      where: { id: bookId },
+      include: {
+        reflection: true,
+      },
+    });
+
+    if (!refreshed) {
+      throw new RepositoryNotFoundError("対象の書籍が見つかりません。");
+    }
+
+    return toBook(refreshed);
+  }
+
+  async addProgressLog(
+    bookId: string,
+    input: CreateProgressLogInput
+  ): Promise<{ book: Book; log: ProgressLog }> {
+    const source = await prisma.bookRecordBook.findUnique({
+      where: { id: bookId },
+      include: {
+        reflection: true,
+      },
+    });
+
+    if (!source) {
+      throw new RepositoryNotFoundError("対象の書籍が見つかりません。");
+    }
+
+    const validationErrors = validateProgressDraft({
+      page: input.page,
+      totalPages: source.totalPages,
+      status: input.status,
+      memo: input.memo ?? "",
+    });
+    if (Object.keys(validationErrors).length > 0) {
+      throw new RepositoryValidationError(firstValidationMessage(validationErrors));
+    }
+
+    let status: BookStatus = input.status;
+    if (input.page >= source.totalPages) {
+      status = "completed";
+    }
+
+    if (status === "completed" && input.page < source.totalPages) {
+      throw new RepositoryValidationError(
+        "完読にするには到達ページを総ページ以上にしてください。"
+      );
+    }
+
+    const loggedAt = parseLoggedAt(input.loggedAt);
+    const completedAt = status === "completed" ? source.completedAt ?? loggedAt : null;
+
+    const [book, log] = await prisma.$transaction([
+      prisma.bookRecordBook.update({
+        where: { id: bookId },
+        data: {
+          currentPage: input.page,
+          status: status as BookRecordStatus,
+          completedAt,
+        },
+        include: {
+          reflection: true,
+        },
+      }),
+      prisma.bookRecordProgressLog.create({
+        data: {
+          bookId,
+          page: input.page,
+          memo: input.memo?.trim() || null,
+          status: status as BookRecordStatus,
+          loggedAt,
+        },
+      }),
+    ]);
+
+    return {
+      book: toBook(book),
+      log: toProgressLog(log),
+    };
+  }
+
+  async saveReflection(bookId: string, input: ReflectionInput): Promise<Book> {
+    const source = await prisma.bookRecordBook.findUnique({
+      where: { id: bookId },
+      include: {
+        reflection: true,
+      },
+    });
+
+    if (!source) {
+      throw new RepositoryNotFoundError("対象の書籍が見つかりません。");
+    }
+
+    const validationErrors = validateReflection(input);
+    if (Object.keys(validationErrors).length > 0) {
+      throw new RepositoryValidationError(firstValidationMessage(validationErrors));
+    }
+
+    await prisma.$transaction([
+      prisma.bookRecordReflection.upsert({
+        where: {
+          bookId,
+        },
+        create: {
+          bookId,
+          learning: input.learning,
+          action: input.action,
+          quote: input.quote,
+          createdAt: source.reflection?.createdAt ?? new Date(),
+        },
+        update: {
+          learning: input.learning,
+          action: input.action,
+          quote: input.quote,
+        },
+      }),
+      prisma.bookRecordBook.update({
+        where: { id: bookId },
+        data: {
+          updatedAt: new Date(),
+        },
+      }),
+    ]);
+
+    const updated = await prisma.bookRecordBook.findUnique({
+      where: {
+        id: bookId,
+      },
+      include: {
+        reflection: true,
+      },
+    });
+
+    if (!updated) {
+      throw new RepositoryNotFoundError("対象の書籍が見つかりません。");
+    }
+
+    return toBook(updated);
+  }
+
+  async searchBooks(query: string): Promise<Book[]> {
+    const normalized = query.trim().toLocaleLowerCase();
+    const books = await this.listBooks();
+
+    if (!normalized) {
+      return books;
+    }
+
+    return books.filter((book) => {
+      const target = [book.title, book.author, ...(book.tags ?? [])].join(" ").toLocaleLowerCase();
+      return target.includes(normalized);
+    });
+  }
+}

--- a/front/src/lib/server/prisma-client.ts
+++ b/front/src/lib/server/prisma-client.ts
@@ -1,0 +1,17 @@
+import "server-only";
+
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  var __prismaClient__: PrismaClient | undefined;
+}
+
+export const prisma =
+  global.__prismaClient__ ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  global.__prismaClient__ = prisma;
+}


### PR DESCRIPTION
## Summary
- add Prisma-based `BookRecord*` schema and Supabase sync scripts (`prisma:pull`, `prisma:validate`, `prisma:generate`)
- add server-side `PrismaBookRecordRepository` + Route Handlers under `/api/book-record/*`
- add client-side `ApiRepository` and repository driver switching (`NEXT_PUBLIC_REPOSITORY_DRIVER`)
- remove UI dependence on `readRawPayload()` and fetch logs via repository interface
- stabilize Playwright by forcing `local` driver and disabling `reuseExistingServer`
- update docs for env/prisma flow/test rules/task status

## Verification
- `pnpm lint`
- `pnpm build`
- `pnpm test:e2e` (18 passed)
- Supabase CRUD smoke check via `/api/book-record/*` and cleanup confirmed