### PR TITLE
feat: Supabase Auth導入と閲覧公開範囲の整理

### DIFF
--- a/docs/03.requirements.md
+++ b/docs/03.requirements.md
@@ -10,6 +10,7 @@
 - ステータス: `読書前` / `読書中` / `保留` / `完読`
 - 完読後に再読（`読書中`へ戻す）を許可
 - 技術スタック: Next.js / TypeScript / Tailwind CSS
+- 認証: Supabase Auth（Google OAuth）
 - E2Eテスト: Playwright
 - データベース: Supabase（将来接続）
 - ユーザープロフィール機能はMVP対象外（必要時に追加検討）
@@ -42,6 +43,11 @@
 7. 統計レポート画面
 - `/stats` で登録書籍数、完読率、ステータス分布、読書形式分布を表示できる
 - 集計データは Phase 1 では localStorage の `books` / `progressLogs` から算出する
+
+8. 認証
+- `/auth/login` からGoogle OAuthでログインできる
+- `supabase` モード時、閲覧系（ホーム `/`・統計 `/stats` で利用する取得処理）は未ログインでも利用できる
+- `supabase` モード時、更新系（書籍登録・進捗記録・感想保存・再読）は認証済みユーザーのみ利用できる
 
 ## 3. 非機能要件
 - モバイル優先UI

--- a/docs/08.api-and-repository.md
+++ b/docs/08.api-and-repository.md
@@ -59,3 +59,10 @@
   - このリポジトリで再度 `db pull` を行い、最新定義に同期する
 - 禁止事項（このリポジトリ）
   - `db push` / `migrate` の直接実行
+
+## 8. 認証契約（Supabase Auth）
+- ログイン方式は Supabase Auth の Google OAuth を利用する
+- クライアントは `ApiRepository` から `/api/book-record/*` を呼び出す際、Supabaseセッションが存在する場合のみ `Authorization: Bearer <token>` を送信する
+- 閲覧系GET（`GET /api/book-record/books` / `GET /api/book-record/books/[id]` / `GET /api/book-record/books/[id]/progress-logs`）は未認証でも利用できる
+- 更新系（`POST /api/book-record/books` / `PATCH /api/book-record/books/[id]` / `POST /api/book-record/books/[id]/progress-logs` / `POST /api/book-record/books/[id]/reflection`）はBearerトークン必須で、未認証は `401` を返す
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` はこのリポジトリの `.env.local` では管理しない（Supabase Authプロジェクト側で管理する）

--- a/docs/10.implementation-tasks.md
+++ b/docs/10.implementation-tasks.md
@@ -71,6 +71,9 @@
 | S4 | 画面のLocalStorage専用依存（`readRawPayload`）除去 | done |
 | S5 | E2E再整備（localStorage前提で18ケース実行） | done |
 | S6 | Supabase運用確認（実データCRUD） | done |
+| S7 | Supabase Auth（Google OAuth）導入とAPI認証ガード実装 | done |
 
 補足:
 - 2026-02-07 に `/api/book-record/*` 経由で create/get/patch/addProgressLog/saveReflection/reread を実行し、検証データは削除済み
+- S7 はアプリ側で `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` を持たず、Supabase Authプロジェクト側のGoogle Provider設定を前提とする
+- 2026-02-07 仕様更新: `home (/)` と `stats (/stats)` は未ログイン閲覧可。更新系操作は引き続きログイン必須

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,7 +1,14 @@
 # Supabase client (browser)
 NEXT_PUBLIC_SUPABASE_URL="https://your-project-ref.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key"
+# Optional (if your project uses publishable key naming)
+# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="your-publishable-key"
+# NOTE:
+# - This app does NOT use GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET in .env.local.
+# - Google OAuth provider credentials are managed on the Supabase Auth project side.
 NEXT_PUBLIC_REPOSITORY_DRIVER="supabase"
+# Supabase Auth redirect URL example:
+# http://localhost:3000/auth/login
 
 # Supabase + Prisma (server / CLI)
 # NOTE: This repository syncs schema by pull. Do not run push here.

--- a/front/README.md
+++ b/front/README.md
@@ -24,12 +24,25 @@ cp .env.example .env.local
 
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`（任意、利用時のみ）
 - `NEXT_PUBLIC_REPOSITORY_DRIVER`（`supabase` or `local`）
 - `DATABASE_URL`
 - `DIRECT_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`（サーバー用途のみ）
 
 実値は `.env.local` に設定し、`.env.example` は共有テンプレートとして管理します。
+`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` はこのリポジトリでは使用しません（Supabase Authプロジェクト側で管理）。
+
+## Supabase Auth（Google OAuth）設定
+
+1. Supabase Authプロジェクト側で `Auth > Providers > Google` が有効化済みであることを確認する
+2. `Auth > URL Configuration` で Redirect URL に以下を追加する
+   - `http://localhost:3000/auth/login`
+   - 本番URLを使う場合は同様に `/auth/login` を追加する
+3. `NEXT_PUBLIC_REPOSITORY_DRIVER=supabase` で起動し、`/auth/login` からログインする
+4. 認可ポリシー
+   - 閲覧系（`/` と `/stats`）は未ログインでも閲覧可能
+   - 更新系（書籍登録・進捗記録・感想保存・再読）はログイン必須
 
 ## Supabase + Prisma運用（チームルール）
 
@@ -58,6 +71,7 @@ cp .env.example .env.local
 ## Routes
 
 - `/`: ダッシュボード
+- `/auth/login`: Googleログイン
 - `/books/new`: 書籍登録
 - `/books/[id]`: 書籍詳細・進捗記録
 - `/stats`: 統計レポート

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",
+    "@supabase/supabase-js": "^2.95.3",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@prisma/client':
         specifier: ^6.16.2
         version: 6.16.2(prisma@6.16.2(typescript@5.9.3))(typescript@5.9.3)
+      '@supabase/supabase-js':
+        specifier: ^2.95.3
+        version: 2.95.3
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -464,6 +467,30 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.95.3':
+    resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.95.3':
+    resolution: {integrity: sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.95.3':
+    resolution: {integrity: sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.95.3':
+    resolution: {integrity: sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.95.3':
+    resolution: {integrity: sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.95.3':
+    resolution: {integrity: sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -570,6 +597,9 @@ packages:
   '@types/node@20.19.32':
     resolution: {integrity: sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -577,6 +607,9 @@ packages:
 
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.54.0':
     resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
@@ -1307,6 +1340,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2074,6 +2111,18 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2477,6 +2526,44 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.95.3':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.95.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.95.3':
+    dependencies:
+      '@supabase/auth-js': 2.95.3
+      '@supabase/functions-js': 2.95.3
+      '@supabase/postgrest-js': 2.95.3
+      '@supabase/realtime-js': 2.95.3
+      '@supabase/storage-js': 2.95.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2565,6 +2652,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.13)':
     dependencies:
       '@types/react': 19.2.13
@@ -2572,6 +2661,10 @@ snapshots:
   '@types/react@19.2.13':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.32
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3115,8 +3208,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -3142,7 +3235,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3153,22 +3246,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3179,7 +3272,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3474,6 +3567,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 
@@ -4345,6 +4440,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  ws@8.19.0: {}
 
   yallist@3.1.1: {}
 

--- a/front/src/app/api/book-record/books/[id]/progress-logs/route.ts
+++ b/front/src/app/api/book-record/books/[id]/progress-logs/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { CreateProgressLogInput } from "@/lib/types";
+import { isAuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
 import {
   isRepositoryError,
   PrismaBookRecordRepository,
@@ -57,6 +58,10 @@ export async function GET(_request: NextRequest, context: Params) {
     const logs = await repository.listProgressLogs(id);
     return NextResponse.json({ logs });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }
@@ -67,6 +72,7 @@ export async function GET(_request: NextRequest, context: Params) {
 
 export async function POST(request: NextRequest, context: Params) {
   try {
+    await requireAuthenticatedUser(request);
     const { id } = await context.params;
     const body = await request.json();
     const input = parseCreateProgressInput(body);
@@ -78,6 +84,10 @@ export async function POST(request: NextRequest, context: Params) {
     const payload = await repository.addProgressLog(id, input);
     return NextResponse.json(payload, { status: 201 });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }

--- a/front/src/app/api/book-record/books/[id]/reflection/route.ts
+++ b/front/src/app/api/book-record/books/[id]/reflection/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ReflectionInput } from "@/lib/types";
+import { isAuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
 import {
   isRepositoryError,
   PrismaBookRecordRepository,
@@ -41,6 +42,7 @@ type Params = {
 
 export async function POST(request: NextRequest, context: Params) {
   try {
+    await requireAuthenticatedUser(request);
     const { id } = await context.params;
     const body = await request.json();
     const input = parseReflectionInput(body);
@@ -52,6 +54,10 @@ export async function POST(request: NextRequest, context: Params) {
     const book = await repository.saveReflection(id, input);
     return NextResponse.json({ book });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }

--- a/front/src/app/api/book-record/books/[id]/route.ts
+++ b/front/src/app/api/book-record/books/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { UpdateBookInput } from "@/lib/types";
+import { isAuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
 import {
   isRepositoryError,
   PrismaBookRecordRepository,
@@ -84,6 +85,10 @@ export async function GET(_request: NextRequest, context: Params) {
 
     return NextResponse.json({ book });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }
@@ -94,6 +99,7 @@ export async function GET(_request: NextRequest, context: Params) {
 
 export async function PATCH(request: NextRequest, context: Params) {
   try {
+    await requireAuthenticatedUser(request);
     const { id } = await context.params;
     const body = await request.json();
     const patch = parseUpdateBookInput(body);
@@ -105,6 +111,10 @@ export async function PATCH(request: NextRequest, context: Params) {
     const book = await repository.updateBook(id, patch);
     return NextResponse.json({ book });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }

--- a/front/src/app/api/book-record/books/route.ts
+++ b/front/src/app/api/book-record/books/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { CreateBookInput } from "@/lib/types";
+import { isAuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
 import {
   isRepositoryError,
   PrismaBookRecordRepository,
@@ -55,6 +56,10 @@ export async function GET() {
     const books = await repository.listBooks();
     return NextResponse.json({ books });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }
@@ -65,6 +70,7 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    await requireAuthenticatedUser(request);
     const body = await request.json();
     const input = parseCreateBookInput(body);
 
@@ -75,6 +81,10 @@ export async function POST(request: NextRequest) {
     const book = await repository.createBook(input);
     return NextResponse.json({ book }, { status: 201 });
   } catch (error) {
+    if (isAuthGuardError(error)) {
+      return errorResponse(error.message, error.statusCode);
+    }
+
     if (isRepositoryError(error)) {
       return errorResponse(error.message, error.statusCode);
     }

--- a/front/src/app/auth/login/page.tsx
+++ b/front/src/app/auth/login/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { getSupabaseBrowserClient, isSupabaseAuthConfigured } from "@/lib/supabase/client";
+import { repositoryDriver } from "@/lib/repository-instance";
+
+const sanitizeNextPath = (value: string | null): string => {
+  if (!value || !value.startsWith("/")) {
+    return "/";
+  }
+
+  return value;
+};
+
+const LoginContent = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const authRequired = repositoryDriver === "supabase";
+  const nextPath = useMemo(() => sanitizeNextPath(searchParams.get("next")), [searchParams]);
+
+  useEffect(() => {
+    if (!authRequired || !isSupabaseAuthConfigured) {
+      return;
+    }
+
+    const supabase = getSupabaseBrowserClient();
+    let active = true;
+
+    const sync = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (!active) {
+        return;
+      }
+
+      if (data.session) {
+        router.replace(nextPath);
+      }
+    };
+
+    void sync();
+
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!active) {
+        return;
+      }
+
+      if (session) {
+        router.replace(nextPath);
+      }
+    });
+
+    return () => {
+      active = false;
+      data.subscription.unsubscribe();
+    };
+  }, [authRequired, nextPath, router]);
+
+  const handleGoogleLogin = async () => {
+    if (!authRequired) {
+      router.replace(nextPath);
+      return;
+    }
+
+    if (!isSupabaseAuthConfigured) {
+      setErrorMessage("Supabase Authの環境変数が不足しています。");
+      return;
+    }
+
+    setLoading(true);
+    setErrorMessage("");
+
+    try {
+      const supabase = getSupabaseBrowserClient();
+      const redirectTo = `${window.location.origin}/auth/login?next=${encodeURIComponent(nextPath)}`;
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: { redirectTo },
+      });
+
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Googleログインに失敗しました。";
+      setErrorMessage(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="panel-card mx-auto w-full max-w-md space-y-5 p-8 text-center">
+      <h1 className="text-2xl font-bold text-[color:var(--foreground)]">ログイン</h1>
+      <p className="text-sm text-[color:var(--foreground)]/72">
+        読書記録データの利用にはGoogleログインが必要です。
+      </p>
+
+      {errorMessage && <p className="notice-danger p-3 text-sm">{errorMessage}</p>}
+
+      <button
+        type="button"
+        disabled={loading}
+        onClick={handleGoogleLogin}
+        className="btn-primary inline-flex w-full justify-center px-4 py-2.5 text-sm disabled:opacity-60"
+      >
+        {loading ? "ログイン中..." : "Googleでログイン"}
+      </button>
+
+      <Link href="/" className="btn-secondary inline-flex w-full justify-center px-4 py-2 text-sm">
+        ダッシュボードへ戻る
+      </Link>
+    </section>
+  );
+};
+
+const LoginFallback = () => {
+  return (
+    <section className="panel-card mx-auto w-full max-w-md space-y-4 p-8 text-center">
+      <h1 className="text-2xl font-bold text-[color:var(--foreground)]">ログイン</h1>
+      <p className="text-sm text-[color:var(--foreground)]/72">読み込み中です...</p>
+    </section>
+  );
+};
+
+export default function LoginPage() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full items-center justify-center px-4">
+      <Suspense fallback={<LoginFallback />}>
+        <LoginContent />
+      </Suspense>
+    </main>
+  );
+}

--- a/front/src/app/books/[id]/page.tsx
+++ b/front/src/app/books/[id]/page.tsx
@@ -3,11 +3,13 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS } from "@/lib/constants";
 import { reflectionIsMissing } from "@/lib/helpers";
 import { repository } from "@/lib/repository-instance";
 import { Book, BookStatus, ProgressLog } from "@/lib/types";
+import { useAuthSession } from "@/lib/use-auth-session";
 import { validateProgressForm, ValidationErrors } from "@/lib/validation";
 
 const toProgressRate = (book: Book): number => {
@@ -20,6 +22,7 @@ const toProgressRate = (book: Book): number => {
 export default function BookDetailPage() {
   const params = useParams<{ id: string }>();
   const bookId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const { authRequired, loading: authLoading, isAuthenticated, configError } = useAuthSession();
 
   const [book, setBook] = useState<Book | null>(null);
   const [logs, setLogs] = useState<ProgressLog[]>([]);
@@ -52,6 +55,10 @@ export default function BookDetailPage() {
   }, [book, page, status]);
 
   const load = async () => {
+    if (authRequired && (authLoading || !isAuthenticated)) {
+      return;
+    }
+
     if (!bookId) {
       return;
     }
@@ -84,12 +91,16 @@ export default function BookDetailPage() {
   useEffect(() => {
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bookId]);
+  }, [authLoading, authRequired, bookId, isAuthenticated]);
 
   const handleSaveProgress = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!book) {
+      return;
+    }
+
+    if (authRequired && !isAuthenticated) {
       return;
     }
 
@@ -140,6 +151,10 @@ export default function BookDetailPage() {
       return;
     }
 
+    if (authRequired && !isAuthenticated) {
+      return;
+    }
+
     setErrorMessage("");
     setSaveMessage("");
 
@@ -156,6 +171,23 @@ export default function BookDetailPage() {
       setErrorMessage(error instanceof Error ? error.message : "再読開始に失敗しました。");
     }
   };
+
+  if (authRequired && !authLoading && !isAuthenticated) {
+    return (
+      <OrganicShell
+        title="書籍詳細"
+        subtitle="進捗記録と完読メモ"
+        contentTestId="book-detail-page"
+        action={
+          <Link href="/" className="btn-secondary inline-flex px-4 py-2 text-sm">
+            ダッシュボードへ戻る
+          </Link>
+        }
+      >
+        <AuthRequiredPanel nextPath={bookId ? `/books/${bookId}` : "/"} configError={configError} />
+      </OrganicShell>
+    );
+  }
 
   if (!isLoaded) {
     return (

--- a/front/src/app/books/new/page.tsx
+++ b/front/src/app/books/new/page.tsx
@@ -3,14 +3,17 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS } from "@/lib/constants";
 import { repository } from "@/lib/repository-instance";
 import { BookFormat, BookStatus } from "@/lib/types";
+import { useAuthSession } from "@/lib/use-auth-session";
 import { normalizeTags, validateBookForm, ValidationErrors } from "@/lib/validation";
 
 export default function NewBookPage() {
   const router = useRouter();
+  const { authRequired, loading: authLoading, isAuthenticated, configError } = useAuthSession();
 
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
@@ -25,6 +28,10 @@ export default function NewBookPage() {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (authRequired && !isAuthenticated) {
+      return;
+    }
 
     const parsedTotalPages = Number(totalPages);
     const normalizedTags = normalizeTags(tags);
@@ -65,6 +72,23 @@ export default function NewBookPage() {
     }
   };
 
+  if (authRequired && !authLoading && !isAuthenticated) {
+    return (
+      <OrganicShell
+        title="書籍登録"
+        subtitle="新しい読書対象を記録します"
+        contentTestId="new-book-page"
+        action={
+          <Link href="/" data-testid="book-cancel-link" className="btn-secondary px-4 py-2 text-sm">
+            ダッシュボードへ戻る
+          </Link>
+        }
+      >
+        <AuthRequiredPanel nextPath="/books/new" configError={configError} />
+      </OrganicShell>
+    );
+  }
+
   return (
     <OrganicShell
       title="書籍登録"
@@ -80,9 +104,9 @@ export default function NewBookPage() {
         data-testid="new-book-form"
         onSubmit={handleSubmit}
         noValidate
-        className="panel-card mx-auto w-full max-w-3xl space-y-4 p-5 md:p-6"
+        className="panel-card mx-auto w-full max-w-3xl space-y-6 p-6 md:p-8"
       >
-        <div className="space-y-1">
+        <div className="space-y-2">
           <label htmlFor="title" className="text-sm font-medium text-[color:var(--foreground)]/80">
             タイトル
           </label>
@@ -100,7 +124,7 @@ export default function NewBookPage() {
           )}
         </div>
 
-        <div className="space-y-1">
+        <div className="space-y-2">
           <label htmlFor="author" className="text-sm font-medium text-[color:var(--foreground)]/80">
             著者
           </label>
@@ -118,7 +142,7 @@ export default function NewBookPage() {
           )}
         </div>
 
-        <div className="space-y-1">
+        <div className="space-y-2">
           <label htmlFor="genre" className="text-sm font-medium text-[color:var(--foreground)]/80">
             ジャンル
           </label>
@@ -136,8 +160,8 @@ export default function NewBookPage() {
           )}
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-1">
+        <div className="grid gap-5 sm:grid-cols-2">
+          <div className="space-y-2">
             <label
               htmlFor="format"
               className="text-sm font-medium text-[color:var(--foreground)]/80"
@@ -159,7 +183,7 @@ export default function NewBookPage() {
             </select>
           </div>
 
-          <div className="space-y-1">
+          <div className="space-y-2">
             <label
               htmlFor="totalPages"
               className="text-sm font-medium text-[color:var(--foreground)]/80"
@@ -186,7 +210,7 @@ export default function NewBookPage() {
           </div>
         </div>
 
-        <div className="space-y-1">
+        <div className="space-y-2">
           <label htmlFor="tags" className="text-sm font-medium text-[color:var(--foreground)]/80">
             タグ（カンマ区切り）
           </label>
@@ -204,7 +228,7 @@ export default function NewBookPage() {
           )}
         </div>
 
-        <div className="space-y-1">
+        <div className="space-y-2">
           <label htmlFor="status" className="text-sm font-medium text-[color:var(--foreground)]/80">
             初期ステータス
           </label>

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -59,6 +59,119 @@ body {
   box-shadow: 0 14px 30px rgba(61, 64, 91, 0.07);
 }
 
+.section-tone-not-started {
+  border-color: rgba(184, 124, 62, 0.45);
+  background: linear-gradient(180deg, #ffefdc 0%, #fff7ed 100%);
+}
+
+.section-tone-reading {
+  border-color: rgba(63, 148, 108, 0.44);
+  background: linear-gradient(180deg, #e7f8ee 0%, #f3fcf8 100%);
+}
+
+.section-tone-paused {
+  border-color: rgba(99, 109, 163, 0.44);
+  background: linear-gradient(180deg, #eceffd 0%, #f5f7ff 100%);
+}
+
+.section-tone-completed {
+  border-color: rgba(66, 123, 183, 0.44);
+  background: linear-gradient(180deg, #e7f3ff 0%, #f2f8ff 100%);
+}
+
+.section-tone-pending-reflection {
+  border-color: rgba(190, 128, 34, 0.46);
+  background: linear-gradient(180deg, #ffefd1 0%, #fff7e8 100%);
+}
+
+.section-dot-not-started {
+  background: #b9783d;
+}
+
+.section-dot-reading {
+  background: #308c62;
+}
+
+.section-dot-paused {
+  background: #5b65a1;
+}
+
+.section-dot-completed {
+  background: #397bb7;
+}
+
+.section-dot-pending-reflection {
+  background: #b87423;
+}
+
+.stats-kpi-books {
+  border-color: rgba(184, 124, 62, 0.45);
+  background: linear-gradient(180deg, #ffefdc 0%, #fff7ed 100%);
+}
+
+.stats-kpi-completed {
+  border-color: rgba(66, 123, 183, 0.44);
+  background: linear-gradient(180deg, #e7f3ff 0%, #f2f8ff 100%);
+}
+
+.stats-kpi-progress {
+  border-color: rgba(63, 148, 108, 0.44);
+  background: linear-gradient(180deg, #e7f8ee 0%, #f3fcf8 100%);
+}
+
+.stats-kpi-pages {
+  border-color: rgba(190, 128, 34, 0.46);
+  background: linear-gradient(180deg, #ffefd1 0%, #fff7e8 100%);
+}
+
+.status-bar-not-started {
+  background: #b9783d;
+}
+
+.status-bar-reading {
+  background: #308c62;
+}
+
+.status-bar-paused {
+  background: #5b65a1;
+}
+
+.status-bar-completed {
+  background: #397bb7;
+}
+
+.stats-status-dot-not-started {
+  background: #b88f66;
+}
+
+.stats-status-dot-reading {
+  background: #5c9f81;
+}
+
+.stats-status-dot-paused {
+  background: #8e97b2;
+}
+
+.stats-status-dot-completed {
+  background: #6d97b8;
+}
+
+.stats-status-bar-not-started {
+  background: #c9a984;
+}
+
+.stats-status-bar-reading {
+  background: #74ae92;
+}
+
+.stats-status-bar-paused {
+  background: #99a3bd;
+}
+
+.stats-status-bar-completed {
+  background: #80a9c8;
+}
+
 .panel-subtle {
   border: 1px solid rgba(61, 64, 91, 0.1);
   border-radius: 1.2rem;

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -15,6 +15,24 @@ const SECTION_CONFIG: Array<{ status: BookStatus; testId: string }> = [
   { status: "completed", testId: "section-completed" },
 ];
 
+type SectionTone = BookStatus | "pending_reflection";
+
+const SECTION_TONE_CLASS: Record<SectionTone, string> = {
+  not_started: "section-tone-not-started",
+  reading: "section-tone-reading",
+  paused: "section-tone-paused",
+  completed: "section-tone-completed",
+  pending_reflection: "section-tone-pending-reflection",
+};
+
+const SECTION_DOT_CLASS: Record<SectionTone, string> = {
+  not_started: "section-dot-not-started",
+  reading: "section-dot-reading",
+  paused: "section-dot-paused",
+  completed: "section-dot-completed",
+  pending_reflection: "section-dot-pending-reflection",
+};
+
 const filterBooksByQuery = (books: Book[], query: string): Book[] => {
   const normalized = query.trim().toLocaleLowerCase();
 
@@ -61,10 +79,23 @@ const BookCard = ({ book }: { book: Book }) => {
   );
 };
 
-const Section = ({ title, testId, books }: { title: string; testId: string; books: Book[] }) => {
+const Section = ({
+  title,
+  testId,
+  books,
+  tone,
+}: {
+  title: string;
+  testId: string;
+  books: Book[];
+  tone: SectionTone;
+}) => {
   return (
-    <section data-testid={testId} className="panel-soft space-y-3 p-5">
-      <h2 className="text-lg font-semibold text-[color:var(--foreground)]">{title}</h2>
+    <section data-testid={testId} className={`panel-soft ${SECTION_TONE_CLASS[tone]} space-y-3 p-5`}>
+      <h2 className="flex items-center gap-2 text-lg font-semibold text-[color:var(--foreground)]">
+        <span aria-hidden className={`h-2.5 w-2.5 rounded-full ${SECTION_DOT_CLASS[tone]}`} />
+        {title}
+      </h2>
       {books.length === 0 ? (
         <p data-testid={`${testId}-empty`} className="text-sm text-[color:var(--foreground)]/60">
           データがありません。
@@ -280,6 +311,7 @@ export default function DashboardPage() {
                 title={STATUS_LABELS[section.status]}
                 testId={section.testId}
                 books={booksByStatus.get(section.status) ?? []}
+                tone={section.status}
               />
             ))}
 
@@ -287,6 +319,7 @@ export default function DashboardPage() {
               title="感想未記入"
               testId="section-pending-reflection"
               books={pendingReflections}
+              tone="pending_reflection"
             />
           </div>
         </div>

--- a/front/src/app/stats/page.tsx
+++ b/front/src/app/stats/page.tsx
@@ -5,9 +5,23 @@ import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS, STATUS_ORDER } from "@/lib/constants";
 import { computeWeeklySummary } from "@/lib/helpers";
 import { repository } from "@/lib/repository-instance";
-import { Book, ProgressLog } from "@/lib/types";
+import { Book, BookStatus, ProgressLog } from "@/lib/types";
 
 const toPercent = (value: number): number => Math.round(value * 1000) / 10;
+
+const STATUS_BAR_CLASS: Record<BookStatus, string> = {
+  not_started: "stats-status-bar-not-started",
+  reading: "stats-status-bar-reading",
+  paused: "stats-status-bar-paused",
+  completed: "stats-status-bar-completed",
+};
+
+const STATUS_DOT_CLASS: Record<BookStatus, string> = {
+  not_started: "stats-status-dot-not-started",
+  reading: "stats-status-dot-reading",
+  paused: "stats-status-dot-paused",
+  completed: "stats-status-dot-completed",
+};
 
 export default function StatsPage() {
   const [books, setBooks] = useState<Book[]>([]);
@@ -81,14 +95,14 @@ export default function StatsPage() {
       {errorMessage && <p className="notice-danger p-3 text-sm">{errorMessage}</p>}
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <article className="panel-soft p-5">
+        <article className="panel-soft stats-kpi-books p-5">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
             登録書籍数
           </p>
           <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">{books.length}</p>
         </article>
 
-        <article className="panel-soft p-5">
+        <article className="panel-soft stats-kpi-completed p-5">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
             完読率
           </p>
@@ -97,7 +111,7 @@ export default function StatsPage() {
           </p>
         </article>
 
-        <article className="panel-soft p-5">
+        <article className="panel-soft stats-kpi-progress p-5">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
             今週の進捗記録
           </p>
@@ -106,7 +120,7 @@ export default function StatsPage() {
           </p>
         </article>
 
-        <article className="panel-soft p-5">
+        <article className="panel-soft stats-kpi-pages p-5">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
             今週の読了ページ
           </p>
@@ -127,7 +141,11 @@ export default function StatsPage() {
               return (
                 <div key={status} className="space-y-1">
                   <div className="flex items-center justify-between text-sm">
-                    <span className="font-semibold text-[color:var(--foreground)]/82">
+                    <span className="inline-flex items-center gap-2 font-semibold text-[color:var(--foreground)]/82">
+                      <span
+                        aria-hidden
+                        className={`h-2.5 w-2.5 rounded-full ${STATUS_DOT_CLASS[status]}`}
+                      />
                       {STATUS_LABELS[status]}
                     </span>
                     <span className="text-[color:var(--foreground)]/62">
@@ -136,7 +154,7 @@ export default function StatsPage() {
                   </div>
                   <div className="h-2 rounded-full bg-[color:var(--background-soft)]">
                     <div
-                      className="h-2 rounded-full bg-[color:var(--accent)] transition-all"
+                      className={`h-2 rounded-full transition-all ${STATUS_BAR_CLASS[status]}`}
                       style={{ width: `${ratio}%` }}
                     />
                   </div>

--- a/front/src/components/auth-required-panel.tsx
+++ b/front/src/components/auth-required-panel.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+type AuthRequiredPanelProps = {
+  nextPath: string;
+  configError?: string | null;
+};
+
+export const AuthRequiredPanel = ({ nextPath, configError }: AuthRequiredPanelProps) => {
+  const loginHref = `/auth/login?next=${encodeURIComponent(nextPath)}`;
+
+  return (
+    <section className="panel-soft mx-auto max-w-xl space-y-3 p-6">
+      <h2 className="text-xl font-bold text-[color:var(--foreground)]">ログインが必要です</h2>
+      <p className="text-sm text-[color:var(--foreground)]/70">
+        Googleアカウントでログインしてから再度お試しください。
+      </p>
+      {configError && <p className="notice-danger p-3 text-sm">{configError}</p>}
+      <Link href={loginHref} className="btn-primary inline-flex px-4 py-2 text-sm">
+        Googleでログイン
+      </Link>
+    </section>
+  );
+};

--- a/front/src/components/organic-shell.tsx
+++ b/front/src/components/organic-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ReactNode, useMemo, useState } from "react";
+import { useAuthSession } from "@/lib/use-auth-session";
+import { getSupabaseBrowserClient } from "@/lib/supabase/client";
 
 const NAV_ITEMS: Array<{ href: string; label: string }> = [
   { href: "/", label: "ホーム" },
@@ -35,6 +37,27 @@ export const OrganicShell = ({
   children,
 }: OrganicShellProps) => {
   const pathname = usePathname();
+  const router = useRouter();
+  const [signingOut, setSigningOut] = useState(false);
+  const { authRequired, isAuthenticated } = useAuthSession();
+
+  const loginHref = useMemo(() => {
+    const nextPath = pathname || "/";
+    return `/auth/login?next=${encodeURIComponent(nextPath)}`;
+  }, [pathname]);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+
+    try {
+      const supabase = getSupabaseBrowserClient();
+      await supabase.auth.signOut();
+      router.replace(loginHref);
+      router.refresh();
+    } finally {
+      setSigningOut(false);
+    }
+  };
 
   return (
     <div className="flex min-h-screen w-full overflow-hidden bg-[color:var(--background)] text-[color:var(--foreground)]">
@@ -76,7 +99,7 @@ export const OrganicShell = ({
         </nav>
 
         <div className="mt-7 rounded-[28px] border border-[color:var(--border)] bg-white/70 p-4 text-xs text-[color:var(--foreground)]/72">
-          <p>localStorage / Playwright E2E</p>
+          <p>{authRequired ? "Supabase Auth / Google OAuth" : "localStorage / Playwright E2E"}</p>
         </div>
       </aside>
 
@@ -106,6 +129,21 @@ export const OrganicShell = ({
 
             <div className="flex items-center gap-3 md:gap-5">
               {action && <div className="flex items-center gap-2">{action}</div>}
+              {authRequired &&
+                (isAuthenticated ? (
+                  <button
+                    type="button"
+                    onClick={handleSignOut}
+                    disabled={signingOut}
+                    className="btn-secondary px-3 py-2 text-xs disabled:opacity-60"
+                  >
+                    {signingOut ? "ログアウト中..." : "ログアウト"}
+                  </button>
+                ) : (
+                  <Link href={loginHref} className="btn-primary px-3 py-2 text-xs">
+                    ログイン
+                  </Link>
+                ))}
               <button
                 type="button"
                 className="flex h-11 w-11 items-center justify-center rounded-full hover:bg-[color:var(--background)]"
@@ -116,13 +154,15 @@ export const OrganicShell = ({
               <div className="hidden h-8 w-px bg-[color:var(--foreground)]/12 md:block" />
               <div className="hidden items-center gap-3 md:flex">
                 <div className="text-right">
-                  <p className="text-xs font-bold leading-none">Single User</p>
+                  <p className="max-w-[220px] truncate text-xs font-bold leading-none">
+                    {authRequired ? "Manager" : "Single User"}
+                  </p>
                   <p className="mt-1 text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--foreground)]/45">
-                    MVP
+                    {authRequired ? "Supabase Auth" : "MVP"}
                   </p>
                 </div>
                 <div className="flex h-11 w-11 items-center justify-center rounded-[20px] bg-[color:var(--background-soft)] text-xs font-bold">
-                  KU
+                  {authRequired ? "M" : "KU"}
                 </div>
               </div>
             </div>

--- a/front/src/lib/api-repository.ts
+++ b/front/src/lib/api-repository.ts
@@ -7,10 +7,20 @@ import {
   ReflectionInput,
   UpdateBookInput,
 } from "./types";
+import { getSupabaseBrowserClient, isSupabaseAuthConfigured } from "./supabase/client";
 
 type ApiError = {
   message?: string;
 };
+
+class HttpError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
 
 const readErrorMessage = async (response: Response): Promise<string> => {
   try {
@@ -27,16 +37,31 @@ const readErrorMessage = async (response: Response): Promise<string> => {
 
 export class ApiRepository implements BookRepository {
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    if (!isSupabaseAuthConfigured) {
+      throw new Error("Supabase Authの環境変数が不足しています。");
+    }
+
+    const supabase = getSupabaseBrowserClient();
+    const sessionResult = await supabase.auth.getSession();
+    if (sessionResult.error) {
+      throw new Error("ログインセッションの取得に失敗しました。");
+    }
+
+    const accessToken = sessionResult.data.session?.access_token;
+
+    const headers = new Headers(init?.headers);
+    headers.set("content-type", "application/json");
+    if (accessToken) {
+      headers.set("authorization", `Bearer ${accessToken}`);
+    }
+
     const response = await fetch(path, {
       ...init,
-      headers: {
-        "content-type": "application/json",
-        ...(init?.headers ?? {}),
-      },
+      headers,
     });
 
     if (!response.ok) {
-      throw new Error(await readErrorMessage(response));
+      throw new HttpError(await readErrorMessage(response), response.status);
     }
 
     return (await response.json()) as T;
@@ -48,17 +73,15 @@ export class ApiRepository implements BookRepository {
   }
 
   async getBook(bookId: string): Promise<Book | null> {
-    const response = await fetch(`/api/book-record/books/${bookId}`);
-    if (response.status === 404) {
-      return null;
+    try {
+      const data = await this.request<{ book: Book }>(`/api/book-record/books/${bookId}`);
+      return data.book;
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 404) {
+        return null;
+      }
+      throw error;
     }
-
-    if (!response.ok) {
-      throw new Error(await readErrorMessage(response));
-    }
-
-    const data = (await response.json()) as { book: Book };
-    return data.book;
   }
 
   async listProgressLogs(bookId: string): Promise<ProgressLog[]> {

--- a/front/src/lib/repository-instance.ts
+++ b/front/src/lib/repository-instance.ts
@@ -21,5 +21,7 @@ const decideDriver = (): "local" | "supabase" => {
 
 const driver = decideDriver();
 
+export const repositoryDriver = driver;
+
 export const repository: BookRepository =
   driver === "supabase" ? new ApiRepository() : new LocalStorageRepository();

--- a/front/src/lib/server/auth-guard.ts
+++ b/front/src/lib/server/auth-guard.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import { createClient } from "@supabase/supabase-js";
+import { NextRequest } from "next/server";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+const serverAuthClient =
+  supabaseUrl && supabaseKey
+    ? createClient(supabaseUrl, supabaseKey, {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+          detectSessionInUrl: false,
+        },
+      })
+    : null;
+
+export class AuthGuardError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+export const isAuthGuardError = (value: unknown): value is AuthGuardError => {
+  return value instanceof AuthGuardError;
+};
+
+export const requireAuthenticatedUser = async (request: NextRequest): Promise<void> => {
+  if (!serverAuthClient) {
+    throw new AuthGuardError("Supabase Authの環境変数が不足しています。", 500);
+  }
+
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    throw new AuthGuardError("ログインが必要です。", 401);
+  }
+
+  const token = authorization.slice("Bearer ".length).trim();
+  if (!token) {
+    throw new AuthGuardError("ログインが必要です。", 401);
+  }
+
+  const { data, error } = await serverAuthClient.auth.getUser(token);
+  if (error || !data.user) {
+    throw new AuthGuardError("ログインが必要です。", 401);
+  }
+};

--- a/front/src/lib/supabase/client.ts
+++ b/front/src/lib/supabase/client.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+let browserClient: SupabaseClient | null = null;
+
+export const isSupabaseAuthConfigured = Boolean(supabaseUrl && supabaseKey);
+
+export const getSupabaseBrowserClient = (): SupabaseClient => {
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("Supabase Authの環境変数が不足しています。");
+  }
+
+  if (!browserClient) {
+    browserClient = createClient(supabaseUrl, supabaseKey);
+  }
+
+  return browserClient;
+};

--- a/front/src/lib/use-auth-session.ts
+++ b/front/src/lib/use-auth-session.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { Session } from "@supabase/supabase-js";
+import { useEffect, useMemo, useState } from "react";
+import { repositoryDriver } from "./repository-instance";
+import { getSupabaseBrowserClient, isSupabaseAuthConfigured } from "./supabase/client";
+
+type AuthSessionState = {
+  authRequired: boolean;
+  loading: boolean;
+  session: Session | null;
+  isAuthenticated: boolean;
+  configError: string | null;
+};
+
+export const useAuthSession = (): AuthSessionState => {
+  const authRequired = repositoryDriver === "supabase";
+  const authConfigured = isSupabaseAuthConfigured;
+  const configError =
+    authRequired && !authConfigured ? "Supabase Authの環境変数が不足しています。" : null;
+  const [loading, setLoading] = useState(authRequired && authConfigured);
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    if (!authRequired || !authConfigured) {
+      return;
+    }
+
+    const supabase = getSupabaseBrowserClient();
+    let active = true;
+
+    const bootstrap = async () => {
+      const { data, error } = await supabase.auth.getSession();
+      if (!active) {
+        return;
+      }
+
+      if (error) {
+        setSession(null);
+      } else {
+        setSession(data.session ?? null);
+      }
+
+      setLoading(false);
+    };
+
+    void bootstrap();
+
+    const { data } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (!active) {
+        return;
+      }
+
+      setSession(nextSession);
+      setLoading(false);
+    });
+
+    return () => {
+      active = false;
+      data.subscription.unsubscribe();
+    };
+  }, [authConfigured, authRequired]);
+
+  const isAuthenticated = useMemo(() => {
+    return Boolean(session?.access_token);
+  }, [session]);
+
+  return {
+    authRequired,
+    loading: authRequired && authConfigured ? loading : false,
+    session: authRequired && authConfigured ? session : null,
+    isAuthenticated,
+    configError,
+  };
+};


### PR DESCRIPTION
## Summary
- Supabase Auth (Google OAuth) ログイン導線を追加
- APIの認証ガードを実装し、更新系を認証必須化
- ホーム(`/`) と 統計(`/stats`) は未ログインでも閲覧可能に変更
- ログイン画面・ヘッダー表示・ダッシュボード/統計/書籍登録のUIを改善
- Supabase Auth運用ルールと認証契約を docs / README / env example に反映

## Validation
- pnpm lint
- pnpm build

## Notes
- GitHub Issue 更新は不要のため未実施
