### PR TITLE
fix: VercelビルドでのPrisma enum importエラー修正

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.28.0",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "pnpm prisma:generate && next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/front/src/lib/server/prisma-book-record-repository.ts
+++ b/front/src/lib/server/prisma-book-record-repository.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { BookRecordFormat, BookRecordStatus } from "@prisma/client";
 import type { BookRecordBook, BookRecordProgressLog, BookRecordReflection } from "@prisma/client";
 import { BookRepository } from "@/lib/repository";
 import {
@@ -257,11 +256,11 @@ export class PrismaBookRecordRepository implements BookRepository {
         title: draft.title.trim(),
         author: draft.author.trim(),
         genre: draft.genre?.trim() ? draft.genre.trim() : null,
-        format: draft.format as BookRecordFormat,
+        format: draft.format as BookRecordBook["format"],
         totalPages: draft.totalPages,
         currentPage: 0,
         tags: draft.tags,
-        status: draft.status as BookRecordStatus,
+        status: draft.status as BookRecordBook["status"],
         completedAt: null,
       },
       include: {
@@ -317,11 +316,11 @@ export class PrismaBookRecordRepository implements BookRepository {
         title: merged.title.trim(),
         author: merged.author.trim(),
         genre: merged.genre?.trim() ? merged.genre.trim() : null,
-        format: merged.format as BookRecordFormat,
+        format: merged.format as BookRecordBook["format"],
         totalPages: merged.totalPages,
         currentPage: merged.currentPage,
         tags: merged.tags,
-        status: status as BookRecordStatus,
+        status: status as BookRecordBook["status"],
         completedAt: status === "completed" ? source.completedAt ?? new Date() : null,
       },
       include: {
@@ -416,7 +415,7 @@ export class PrismaBookRecordRepository implements BookRepository {
         where: { id: bookId },
         data: {
           currentPage: input.page,
-          status: status as BookRecordStatus,
+          status: status as BookRecordBook["status"],
           completedAt,
         },
         include: {
@@ -428,7 +427,7 @@ export class PrismaBookRecordRepository implements BookRepository {
           bookId,
           page: input.page,
           memo: input.memo?.trim() || null,
-          status: status as BookRecordStatus,
+          status: status as BookRecordBook["status"],
           loggedAt,
         },
       }),


### PR DESCRIPTION
## Summary
- `@prisma/client` の top-level enum export (`BookRecordFormat` / `BookRecordStatus`) 依存を解消
- `prisma-book-record-repository.ts` で `BookRecordBook["format"]` / `BookRecordBook["status"]` を利用
- `build` 時に `prisma generate` を必ず実行するように変更し、Vercel環境での生成ズレを防止

## Validation
- pnpm lint
- pnpm build
