### PR TITLE
chore: docs-only変更時にVercel buildをスキップ

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -68,6 +68,11 @@ cp .env.example .env.local
 - `pnpm test:e2e:ui`: Playwright UIモード
 - `pnpm test:e2e:headed`: Headed実行
 
+## Vercel Build Skip Rule
+
+- `front/vercel.json` の `ignoreCommand` で、`docs/` のみ変更されたコミットはVercelビルドをスキップする
+- `front/` 配下やその他ファイルの変更がある場合は通常どおりビルドする
+
 ## Routes
 
 - `/`: ダッシュボード

--- a/front/scripts/vercel-ignore-docs.sh
+++ b/front/scripts/vercel-ignore-docs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -eu
+
+PREVIOUS_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
+CURRENT_SHA="${VERCEL_GIT_COMMIT_SHA:-}"
+
+if [ -z "$PREVIOUS_SHA" ] || [ -z "$CURRENT_SHA" ]; then
+  echo "Vercel git SHA is missing. Continue build."
+  exit 1
+fi
+
+CHANGED_FILES="$(git diff --name-only "$PREVIOUS_SHA" "$CURRENT_SHA" || true)"
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No changed files detected. Skip build."
+  exit 0
+fi
+
+for path in $CHANGED_FILES; do
+  case "$path" in
+    docs/*)
+      ;;
+    *)
+      echo "Non-docs change detected: $path. Continue build."
+      exit 1
+      ;;
+  esac
+done
+
+echo "Only docs/ changes detected. Skip build."
+exit 0

--- a/front/vercel.json
+++ b/front/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "sh ./scripts/vercel-ignore-docs.sh"
+}


### PR DESCRIPTION
## Summary
- `front/vercel.json` に `ignoreCommand` を追加
- `front/scripts/vercel-ignore-docs.sh` を追加し、`docs/` のみ変更時はVercelビルドをスキップ
- `front/README.md` にVercel build skipルールを追記

## Behavior
- 変更が `docs/*` のみ: build skip
- `docs/*` 以外を含む: 通常どおり build 実行

## Validation
- pnpm lint
- 判定スクリプト実行確認
