### PR TITLE
feat: 全体ローディング画面と部分ローディングを追加

### DIFF
--- a/docs/10.implementation-tasks.md
+++ b/docs/10.implementation-tasks.md
@@ -72,6 +72,7 @@
 | S5 | E2E再整備（localStorage前提で18ケース実行） | done |
 | S6 | Supabase運用確認（実データCRUD） | done |
 | S7 | Supabase Auth（Google OAuth）導入とAPI認証ガード実装 | done |
+| S8 | 全体的なローディング画面を追加 | done |
 
 補足:
 - 2026-02-07 に `/api/book-record/*` 経由で create/get/patch/addProgressLog/saveReflection/reread を実行し、検証データは削除済み

--- a/front/src/app/books/[id]/page.tsx
+++ b/front/src/app/books/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
+import { GlobalLoadingScreen } from "@/components/global-loading-screen";
 import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS } from "@/lib/constants";
 import { reflectionIsMissing } from "@/lib/helpers";
@@ -190,22 +191,7 @@ export default function BookDetailPage() {
   }
 
   if (!isLoaded) {
-    return (
-      <OrganicShell
-        title="書籍詳細"
-        subtitle="読み込み中"
-        contentTestId="book-detail-page"
-        action={
-          <Link href="/" className="btn-secondary px-4 py-2 text-sm">
-            ダッシュボードへ戻る
-          </Link>
-        }
-      >
-        <div className="panel-soft p-4">
-          <p className="text-sm text-[color:var(--foreground)]/65">読み込み中...</p>
-        </div>
-      </OrganicShell>
-    );
+    return <GlobalLoadingScreen message="書籍データを読み込んでいます..." />;
   }
 
   if (!book) {

--- a/front/src/app/books/new/page.tsx
+++ b/front/src/app/books/new/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
+import { GlobalLoadingScreen } from "@/components/global-loading-screen";
 import { OrganicShell } from "@/components/organic-shell";
 import { FORMAT_LABELS, STATUS_LABELS } from "@/lib/constants";
 import { repository } from "@/lib/repository-instance";
@@ -71,6 +72,10 @@ export default function NewBookPage() {
       setSaving(false);
     }
   };
+
+  if (authRequired && authLoading) {
+    return <GlobalLoadingScreen message="認証状態を確認しています..." />;
+  }
 
   if (authRequired && !authLoading && !isAuthenticated) {
     return (

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -39,6 +39,34 @@ body {
   min-height: 100vh;
 }
 
+.global-loading-canvas {
+  background:
+    radial-gradient(circle at 10% 12%, rgba(129, 178, 154, 0.28), transparent 34%),
+    radial-gradient(circle at 92% 0%, rgba(234, 227, 219, 0.95), transparent 38%), var(--background);
+}
+
+.global-loading-panel {
+  border: 1px solid rgba(61, 64, 91, 0.14);
+  background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 28px 60px rgba(61, 64, 91, 0.12);
+}
+
+.global-loading-spinner {
+  border: 4px solid rgba(129, 178, 154, 0.2);
+  border-top-color: var(--accent-strong);
+  animation: loading-spin 0.9s linear infinite;
+}
+
+@keyframes loading-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .theme-canvas {
   min-height: 100vh;
   color: var(--foreground);

--- a/front/src/app/loading.tsx
+++ b/front/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { GlobalLoadingScreen } from "@/components/global-loading-screen";
+
+export default function Loading() {
+  return <GlobalLoadingScreen message="ページを準備しています..." />;
+}

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -114,6 +114,7 @@ const Section = ({
 export default function DashboardPage() {
   const [books, setBooks] = useState<Book[]>([]);
   const [logs, setLogs] = useState<ProgressLog[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
   const [query, setQuery] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [recoveryNotice, setRecoveryNotice] = useState<string | null>(null);
@@ -131,6 +132,8 @@ export default function DashboardPage() {
       } catch (error) {
         const message = error instanceof Error ? error.message : "データの読み込みに失敗しました。";
         setErrorMessage(message);
+      } finally {
+        setIsLoaded(true);
       }
     };
 
@@ -234,149 +237,167 @@ export default function DashboardPage() {
         </div>
       </section>
 
-      {recoveryNotice && (
-        <p data-testid="recovery-message" className="notice-warn p-3 text-sm">
-          破損したデータを検知したため初期化し、バックアップを作成しました。
-        </p>
-      )}
-
-      {errorMessage && (
-        <p data-testid="dashboard-error" className="notice-danger p-3 text-sm">
-          {errorMessage}
-        </p>
-      )}
-
-      {invalidBookCount > 0 && (
-        <p data-testid="invalid-book-warning" className="notice-danger p-3 text-sm">
-          総ページ数が不正な書籍が {invalidBookCount} 件あるため表示対象から除外しました。
-        </p>
-      )}
-
-      <div className="grid grid-cols-1 gap-8 xl:grid-cols-3">
-        <div className="space-y-4 xl:col-span-2">
-          <section className="panel-soft p-5">
-            <label
-              htmlFor="search"
-              className="mb-2 block text-sm font-medium text-[color:var(--foreground)]/78"
-            >
-              検索
-            </label>
-            <input
-              id="search"
-              data-testid="search-input"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="タイトル・著者・タグで検索"
-              className="field-input"
-            />
-          </section>
-
-          <section
-            data-testid="weekly-summary"
-            className="panel-soft grid gap-3 p-4 sm:grid-cols-3"
-          >
-            <div className="panel-subtle px-3 py-3">
-              <p className="text-xs text-[color:var(--foreground)]/58">直近7日の読了ページ数</p>
-              <p
-                data-testid="weekly-read-pages"
-                className="text-2xl font-bold text-[color:var(--foreground)]"
-              >
-                {weeklySummary.readPages}
-              </p>
-            </div>
-            <div className="panel-subtle px-3 py-3">
-              <p className="text-xs text-[color:var(--foreground)]/58">直近7日の進捗記録回数</p>
-              <p
-                data-testid="weekly-progress-count"
-                className="text-2xl font-bold text-[color:var(--foreground)]"
-              >
-                {weeklySummary.progressCount}
-              </p>
-            </div>
-            <div className="panel-subtle px-3 py-3">
-              <p className="text-xs text-[color:var(--foreground)]/58">直近7日の感想数</p>
-              <p
-                data-testid="weekly-reflection-count"
-                className="text-2xl font-bold text-[color:var(--foreground)]"
-              >
-                {weeklySummary.reflectionCount}
-              </p>
-            </div>
-          </section>
-
-          <div className="space-y-4">
-            {SECTION_CONFIG.map((section) => (
-              <Section
-                key={section.status}
-                title={STATUS_LABELS[section.status]}
-                testId={section.testId}
-                books={booksByStatus.get(section.status) ?? []}
-                tone={section.status}
+      {!isLoaded ? (
+        <section data-testid="dashboard-loading" className="panel-soft space-y-4 p-5">
+          <p className="text-sm font-medium text-[color:var(--foreground)]/72">
+            ダッシュボードデータを読み込み中です...
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-24 animate-pulse rounded-2xl bg-[color:var(--background-soft)]/70"
               />
             ))}
-
-            <Section
-              title="感想未記入"
-              testId="section-pending-reflection"
-              books={pendingReflections}
-              tone="pending_reflection"
-            />
           </div>
-        </div>
+        </section>
+      ) : (
+        <>
+          {recoveryNotice && (
+            <p data-testid="recovery-message" className="notice-warn p-3 text-sm">
+              破損したデータを検知したため初期化し、バックアップを作成しました。
+            </p>
+          )}
 
-        <aside className="space-y-4">
-          <section className="panel-soft p-6">
-            <h3 className="flex items-center gap-2 text-lg font-bold">
-              <span className="text-base">🏅</span>
-              今週のバッジ
-            </h3>
-            <div className="mt-4 space-y-3">
-              {badges.map((badge) => (
-                <article
-                  key={badge.id}
-                  className={`rounded-2xl border p-3 ${
-                    badge.achieved
-                      ? "border-[color:var(--accent)]/30 bg-[color:var(--accent)]/10"
-                      : "border-[color:var(--border)] bg-white/70"
-                  }`}
+          {errorMessage && (
+            <p data-testid="dashboard-error" className="notice-danger p-3 text-sm">
+              {errorMessage}
+            </p>
+          )}
+
+          {invalidBookCount > 0 && (
+            <p data-testid="invalid-book-warning" className="notice-danger p-3 text-sm">
+              総ページ数が不正な書籍が {invalidBookCount} 件あるため表示対象から除外しました。
+            </p>
+          )}
+
+          <div className="grid grid-cols-1 gap-8 xl:grid-cols-3">
+            <div className="space-y-4 xl:col-span-2">
+              <section className="panel-soft p-5">
+                <label
+                  htmlFor="search"
+                  className="mb-2 block text-sm font-medium text-[color:var(--foreground)]/78"
                 >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex items-start gap-2.5">
-                      <span className="text-xl">{badge.icon}</span>
-                      <div>
-                        <p className="text-sm font-bold text-[color:var(--foreground)]">
-                          {badge.label}
-                        </p>
-                        <p className="text-xs text-[color:var(--foreground)]/62">
-                          {badge.condition}
-                        </p>
-                      </div>
-                    </div>
-                    <span
-                      className={`rounded-full px-2 py-1 text-[10px] font-bold ${
+                  検索
+                </label>
+                <input
+                  id="search"
+                  data-testid="search-input"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="タイトル・著者・タグで検索"
+                  className="field-input"
+                />
+              </section>
+
+              <section
+                data-testid="weekly-summary"
+                className="panel-soft grid gap-3 p-4 sm:grid-cols-3"
+              >
+                <div className="panel-subtle px-3 py-3">
+                  <p className="text-xs text-[color:var(--foreground)]/58">直近7日の読了ページ数</p>
+                  <p
+                    data-testid="weekly-read-pages"
+                    className="text-2xl font-bold text-[color:var(--foreground)]"
+                  >
+                    {weeklySummary.readPages}
+                  </p>
+                </div>
+                <div className="panel-subtle px-3 py-3">
+                  <p className="text-xs text-[color:var(--foreground)]/58">直近7日の進捗記録回数</p>
+                  <p
+                    data-testid="weekly-progress-count"
+                    className="text-2xl font-bold text-[color:var(--foreground)]"
+                  >
+                    {weeklySummary.progressCount}
+                  </p>
+                </div>
+                <div className="panel-subtle px-3 py-3">
+                  <p className="text-xs text-[color:var(--foreground)]/58">直近7日の感想数</p>
+                  <p
+                    data-testid="weekly-reflection-count"
+                    className="text-2xl font-bold text-[color:var(--foreground)]"
+                  >
+                    {weeklySummary.reflectionCount}
+                  </p>
+                </div>
+              </section>
+
+              <div className="space-y-4">
+                {SECTION_CONFIG.map((section) => (
+                  <Section
+                    key={section.status}
+                    title={STATUS_LABELS[section.status]}
+                    testId={section.testId}
+                    books={booksByStatus.get(section.status) ?? []}
+                    tone={section.status}
+                  />
+                ))}
+
+                <Section
+                  title="感想未記入"
+                  testId="section-pending-reflection"
+                  books={pendingReflections}
+                  tone="pending_reflection"
+                />
+              </div>
+            </div>
+
+            <aside className="space-y-4">
+              <section className="panel-soft p-6">
+                <h3 className="flex items-center gap-2 text-lg font-bold">
+                  <span className="text-base">🏅</span>
+                  今週のバッジ
+                </h3>
+                <div className="mt-4 space-y-3">
+                  {badges.map((badge) => (
+                    <article
+                      key={badge.id}
+                      className={`rounded-2xl border p-3 ${
                         badge.achieved
-                          ? "bg-[color:var(--accent)] text-white"
-                          : "bg-[color:var(--background-soft)] text-[color:var(--foreground)]/72"
+                          ? "border-[color:var(--accent)]/30 bg-[color:var(--accent)]/10"
+                          : "border-[color:var(--border)] bg-white/70"
                       }`}
                     >
-                      {badge.achieved ? "達成" : "未達成"}
-                    </span>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </section>
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex items-start gap-2.5">
+                          <span className="text-xl">{badge.icon}</span>
+                          <div>
+                            <p className="text-sm font-bold text-[color:var(--foreground)]">
+                              {badge.label}
+                            </p>
+                            <p className="text-xs text-[color:var(--foreground)]/62">
+                              {badge.condition}
+                            </p>
+                          </div>
+                        </div>
+                        <span
+                          className={`rounded-full px-2 py-1 text-[10px] font-bold ${
+                            badge.achieved
+                              ? "bg-[color:var(--accent)] text-white"
+                              : "bg-[color:var(--background-soft)] text-[color:var(--foreground)]/72"
+                          }`}
+                        >
+                          {badge.achieved ? "達成" : "未達成"}
+                        </span>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </section>
 
-          <section className="rounded-[40px] bg-[#3d405b] p-6 text-white shadow-lg">
-            <h3 className="text-lg font-bold">運用メモ</h3>
-            <ul className="mt-4 space-y-2 text-sm text-white/85">
-              <li>完読時に感想を保存</li>
-              <li>再読時はページ0から再開</li>
-              <li>感想は再完読で再編集可能</li>
-            </ul>
-          </section>
-        </aside>
-      </div>
+              <section className="rounded-[40px] bg-[#3d405b] p-6 text-white shadow-lg">
+                <h3 className="text-lg font-bold">運用メモ</h3>
+                <ul className="mt-4 space-y-2 text-sm text-white/85">
+                  <li>完読時に感想を保存</li>
+                  <li>再読時はページ0から再開</li>
+                  <li>感想は再完読で再編集可能</li>
+                </ul>
+              </section>
+            </aside>
+          </div>
+        </>
+      )}
     </OrganicShell>
   );
 }

--- a/front/src/app/stats/page.tsx
+++ b/front/src/app/stats/page.tsx
@@ -26,6 +26,7 @@ const STATUS_DOT_CLASS: Record<BookStatus, string> = {
 export default function StatsPage() {
   const [books, setBooks] = useState<Book[]>([]);
   const [logs, setLogs] = useState<ProgressLog[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
@@ -41,6 +42,8 @@ export default function StatsPage() {
         const message =
           error instanceof Error ? error.message : "統計データの読み込みに失敗しました。";
         setErrorMessage(message);
+      } finally {
+        setIsLoaded(true);
       }
     };
 
@@ -92,128 +95,150 @@ export default function StatsPage() {
       contentTestId="stats-page"
       headerSearchPlaceholder="統計を検索..."
     >
-      {errorMessage && <p className="notice-danger p-3 text-sm">{errorMessage}</p>}
-
-      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <article className="panel-soft stats-kpi-books p-5">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
-            登録書籍数
+      {!isLoaded ? (
+        <section data-testid="stats-loading" className="panel-soft space-y-4 p-5">
+          <p className="text-sm font-medium text-[color:var(--foreground)]/72">
+            統計データを読み込み中です...
           </p>
-          <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">{books.length}</p>
-        </article>
-
-        <article className="panel-soft stats-kpi-completed p-5">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
-            完読率
-          </p>
-          <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">
-            {completionRate}%
-          </p>
-        </article>
-
-        <article className="panel-soft stats-kpi-progress p-5">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
-            今週の進捗記録
-          </p>
-          <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">
-            {weeklySummary.progressCount}
-          </p>
-        </article>
-
-        <article className="panel-soft stats-kpi-pages p-5">
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
-            今週の読了ページ
-          </p>
-          <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">
-            {weeklySummary.readPages}
-          </p>
-        </article>
-      </section>
-
-      <section className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-        <article className="panel-card p-6">
-          <h2 className="text-2xl font-bold text-[color:var(--foreground)]">ステータス分布</h2>
-          <div className="mt-5 space-y-3">
-            {STATUS_ORDER.map((status) => {
-              const count = statusCounts[status];
-              const ratio = books.length === 0 ? 0 : Math.round((count / books.length) * 100);
-
-              return (
-                <div key={status} className="space-y-1">
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="inline-flex items-center gap-2 font-semibold text-[color:var(--foreground)]/82">
-                      <span
-                        aria-hidden
-                        className={`h-2.5 w-2.5 rounded-full ${STATUS_DOT_CLASS[status]}`}
-                      />
-                      {STATUS_LABELS[status]}
-                    </span>
-                    <span className="text-[color:var(--foreground)]/62">
-                      {count}冊 ({ratio}%)
-                    </span>
-                  </div>
-                  <div className="h-2 rounded-full bg-[color:var(--background-soft)]">
-                    <div
-                      className={`h-2 rounded-full transition-all ${STATUS_BAR_CLASS[status]}`}
-                      style={{ width: `${ratio}%` }}
-                    />
-                  </div>
-                </div>
-              );
-            })}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-28 animate-pulse rounded-2xl bg-[color:var(--background-soft)]/70"
+              />
+            ))}
           </div>
-        </article>
-
-        <article className="panel-card p-6">
-          <h2 className="text-2xl font-bold text-[color:var(--foreground)]">読書形式の内訳</h2>
-          <div className="mt-5 space-y-3">
-            {Object.entries(formatCounts).map(([format, count]) => {
-              const typedFormat = format as keyof typeof formatCounts;
-              const ratio = books.length === 0 ? 0 : Math.round((count / books.length) * 100);
-
-              return (
-                <div key={format} className="space-y-1">
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="font-semibold text-[color:var(--foreground)]/82">
-                      {FORMAT_LABELS[typedFormat]}
-                    </span>
-                    <span className="text-[color:var(--foreground)]/62">
-                      {count}冊 ({ratio}%)
-                    </span>
-                  </div>
-                  <div className="h-2 rounded-full bg-[color:var(--background-soft)]">
-                    <div
-                      className="h-2 rounded-full bg-[#3d405b]/75 transition-all"
-                      style={{ width: `${ratio}%` }}
-                    />
-                  </div>
-                </div>
-              );
-            })}
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            <div className="h-64 animate-pulse rounded-3xl bg-[color:var(--background-soft)]/60" />
+            <div className="h-64 animate-pulse rounded-3xl bg-[color:var(--background-soft)]/60" />
           </div>
-        </article>
-      </section>
+        </section>
+      ) : (
+        <>
+          {errorMessage && <p className="notice-danger p-3 text-sm">{errorMessage}</p>}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <article className="panel-subtle p-4">
-          <p className="text-xs text-[color:var(--foreground)]/55">直近7日の感想数</p>
-          <p className="mt-1 text-2xl font-bold text-[color:var(--foreground)]">
-            {weeklySummary.reflectionCount}
-          </p>
-        </article>
-        <article className="panel-subtle p-4">
-          <p className="text-xs text-[color:var(--foreground)]/55">読書中の冊数</p>
-          <p className="mt-1 text-2xl font-bold text-[color:var(--foreground)]">
-            {statusCounts.reading}
-          </p>
-        </article>
-        <article className="panel-subtle p-4">
-          <p className="text-xs text-[color:var(--foreground)]/55">保留中の冊数</p>
-          <p className="mt-1 text-2xl font-bold text-[color:var(--foreground)]">
-            {statusCounts.paused}
-          </p>
-        </article>
-      </section>
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <article className="panel-soft stats-kpi-books p-5">
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
+                登録書籍数
+              </p>
+              <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">{books.length}</p>
+            </article>
+
+            <article className="panel-soft stats-kpi-completed p-5">
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
+                完読率
+              </p>
+              <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">
+                {completionRate}%
+              </p>
+            </article>
+
+            <article className="panel-soft stats-kpi-progress p-5">
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
+                今週の進捗記録
+              </p>
+              <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">
+                {weeklySummary.progressCount}
+              </p>
+            </article>
+
+            <article className="panel-soft stats-kpi-pages p-5">
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--foreground)]/45">
+                今週の読了ページ
+              </p>
+              <p className="mt-2 text-4xl font-bold text-[color:var(--foreground)]">
+                {weeklySummary.readPages}
+              </p>
+            </article>
+          </section>
+
+          <section className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            <article className="panel-card p-6">
+              <h2 className="text-2xl font-bold text-[color:var(--foreground)]">ステータス分布</h2>
+              <div className="mt-5 space-y-3">
+                {STATUS_ORDER.map((status) => {
+                  const count = statusCounts[status];
+                  const ratio = books.length === 0 ? 0 : Math.round((count / books.length) * 100);
+
+                  return (
+                    <div key={status} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="inline-flex items-center gap-2 font-semibold text-[color:var(--foreground)]/82">
+                          <span
+                            aria-hidden
+                            className={`h-2.5 w-2.5 rounded-full ${STATUS_DOT_CLASS[status]}`}
+                          />
+                          {STATUS_LABELS[status]}
+                        </span>
+                        <span className="text-[color:var(--foreground)]/62">
+                          {count}冊 ({ratio}%)
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-[color:var(--background-soft)]">
+                        <div
+                          className={`h-2 rounded-full transition-all ${STATUS_BAR_CLASS[status]}`}
+                          style={{ width: `${ratio}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </article>
+
+            <article className="panel-card p-6">
+              <h2 className="text-2xl font-bold text-[color:var(--foreground)]">読書形式の内訳</h2>
+              <div className="mt-5 space-y-3">
+                {Object.entries(formatCounts).map(([format, count]) => {
+                  const typedFormat = format as keyof typeof formatCounts;
+                  const ratio = books.length === 0 ? 0 : Math.round((count / books.length) * 100);
+
+                  return (
+                    <div key={format} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-semibold text-[color:var(--foreground)]/82">
+                          {FORMAT_LABELS[typedFormat]}
+                        </span>
+                        <span className="text-[color:var(--foreground)]/62">
+                          {count}冊 ({ratio}%)
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-[color:var(--background-soft)]">
+                        <div
+                          className="h-2 rounded-full bg-[#3d405b]/75 transition-all"
+                          style={{ width: `${ratio}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </article>
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <article className="panel-subtle p-4">
+              <p className="text-xs text-[color:var(--foreground)]/55">直近7日の感想数</p>
+              <p className="mt-1 text-2xl font-bold text-[color:var(--foreground)]">
+                {weeklySummary.reflectionCount}
+              </p>
+            </article>
+            <article className="panel-subtle p-4">
+              <p className="text-xs text-[color:var(--foreground)]/55">読書中の冊数</p>
+              <p className="mt-1 text-2xl font-bold text-[color:var(--foreground)]">
+                {statusCounts.reading}
+              </p>
+            </article>
+            <article className="panel-subtle p-4">
+              <p className="text-xs text-[color:var(--foreground)]/55">保留中の冊数</p>
+              <p className="mt-1 text-2xl font-bold text-[color:var(--foreground)]">
+                {statusCounts.paused}
+              </p>
+            </article>
+          </section>
+        </>
+      )}
     </OrganicShell>
   );
 }

--- a/front/src/components/global-loading-screen.tsx
+++ b/front/src/components/global-loading-screen.tsx
@@ -1,0 +1,24 @@
+type GlobalLoadingScreenProps = {
+  message?: string;
+  detail?: string;
+};
+
+export const GlobalLoadingScreen = ({
+  message = "画面を読み込んでいます...",
+  detail = "少々お待ちください。",
+}: GlobalLoadingScreenProps) => {
+  return (
+    <div
+      data-testid="global-loading-screen"
+      className="global-loading-canvas flex min-h-screen items-center justify-center px-4"
+    >
+      <section className="global-loading-panel w-full max-w-md rounded-[36px] px-7 py-10 text-center">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-white/80 shadow-[0_18px_30px_rgba(61,64,91,0.12)]">
+          <div className="global-loading-spinner h-9 w-9 rounded-full" />
+        </div>
+        <p className="mt-6 text-base font-bold text-[color:var(--foreground)]">{message}</p>
+        <p className="mt-2 text-sm text-[color:var(--foreground)]/62">{detail}</p>
+      </section>
+    </div>
+  );
+};


### PR DESCRIPTION
## 関連Issue
Closes #7

## 概要
- 全体ローディングUIコンポーネントを追加
- App Routerの loading.tsx を追加
- ホームと統計レポートは全画面ではなく部分ローディングに変更
- 書籍詳細/新規作成ページの読み込み時表示を整理
- 実装タスクのS8をdoneに更新

## 確認
- pnpm lint
- pnpm build
- pnpm test:e2e（18 passed）
