### PR TITLE
[codex] align docs with supabase and local modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pnpm test:e2e
 
 ## Notes
 
-- Phase 1 のデータ保存先は `localStorage`（キー: `book-reading-record.v1`）
+- データ保存先は `NEXT_PUBLIC_REPOSITORY_DRIVER` で切り替える（`supabase` / `local`）
+- 通常運用は `supabase`、E2E受け入れは `local` を使用する
 - E2E は Playwright（Chromium）
 - 仕様優先順位は `docs/04.e2e-cases.md > docs/03.requirements.md > docs/02.ui-layout.md`

--- a/docs/02.ui-layout.md
+++ b/docs/02.ui-layout.md
@@ -82,7 +82,8 @@
   - ステータス分布（読書前/読書中/保留/完読）
   - 読書形式分布（紙/電子/音声）
 - データソース
-  - Phase 1 は localStorage の `books` / `progressLogs`
+  - `NEXT_PUBLIC_REPOSITORY_DRIVER=supabase`: `/api/book-record/*` 経由でSupabase（Prisma）から取得
+  - `NEXT_PUBLIC_REPOSITORY_DRIVER=local`: localStorage の `book-reading-record.v1` から取得（E2E受け入れで使用）
 
 ## 4. UX方針
 - 進捗入力は30秒以内完了を目標

--- a/docs/03.requirements.md
+++ b/docs/03.requirements.md
@@ -12,7 +12,7 @@
 - 技術スタック: Next.js / TypeScript / Tailwind CSS
 - 認証: Supabase Auth（Google OAuth）
 - E2Eテスト: Playwright
-- データベース: Supabase（将来接続）
+- データ永続化: Supabase（通常運用）/ localStorage（`local` モード）
 - ユーザープロフィール機能はMVP対象外（必要時に追加検討）
 - ローカル開発優先（まずローカルで動作）
 - デプロイ先: Vercel
@@ -42,7 +42,7 @@
 
 7. 統計レポート画面
 - `/stats` で登録書籍数、完読率、ステータス分布、読書形式分布を表示できる
-- 集計データは Phase 1 では localStorage の `books` / `progressLogs` から算出する
+- 集計データは現在のRepositoryドライバー（`supabase` / `local`）から算出する
 
 8. 認証
 - `/auth/login` からGoogle OAuthでログインできる
@@ -52,7 +52,7 @@
 ## 3. 非機能要件
 - モバイル優先UI
 - ローカル開発環境で即起動可能
-- ローカルデータ永続化（開発段階）
+- Repositoryドライバー切替で同一UIから `supabase` / `local` の両方を利用可能
 - `base/` は read-only
 - 実装は `front/` のみ
 

--- a/docs/04.e2e-cases.md
+++ b/docs/04.e2e-cases.md
@@ -7,6 +7,10 @@
 - 実行ルール・前処理・セレクタ方針は `docs/09.test-spec.md` を参照する
 - 本ファイルは受け入れケースのみを定義する
 
+## テストモード前提
+- 本ファイルのCase 1-18は `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で実行する受け入れ基準とする
+- 通常運用（`supabase`）の動作確認は `docs/10.implementation-tasks.md` のSupabase連携タスクで扱う
+
 ## Case 1: 初期表示
 - 前提: localStorage にデータなし
 - 手順:

--- a/docs/05.data-and-storage.md
+++ b/docs/05.data-and-storage.md
@@ -1,7 +1,7 @@
 # Data And Storage Specification
 
 ## 1. 目的
-- 読書記録アプリのデータ構造とローカル保存仕様を定義する
+- 読書記録アプリのデータ構造と永続化仕様（`supabase` / `local`）を定義する
 
 ## 2. データモデル
 
@@ -38,17 +38,29 @@
 - `quote: string`
 - `createdAt: string` (ISO 8601)
 
-### 2.4 StoragePayload
+### 2.4 StoragePayload（`local` モード専用）
 - `version: number`
 - `books: Book[]`
 - `progressLogs: ProgressLog[]`
 
-## 3. データ使用方針（Phase 1）
+## 3. データ使用方針
 - 扱うデータ: 書籍情報、進捗記録、感想
-- ユーザー入力データを外部送信しない
-- ブラウザのローカル保存のみ利用する
+- 画面は `BookRepository` を通じてデータへアクセスする
+- `NEXT_PUBLIC_REPOSITORY_DRIVER=supabase` の場合は `/api/book-record/*` 経由で Supabase DB を利用する
+- `NEXT_PUBLIC_REPOSITORY_DRIVER=local` の場合はブラウザ `localStorage` を利用する
 
-## 4. localStorage 仕様（Phase 1）
+## 4. 永続化モード
+### 4.1 `supabase` モード（通常運用）
+- 保存先: Supabase PostgreSQL（`BookRecord*` テーブル）
+- 参照実装:
+  - `ApiRepository`（クライアント）
+  - Next.js Route Handler（`/api/book-record/*`）
+  - `PrismaBookRecordRepository`（サーバー）
+- 認可:
+  - 閲覧系GETは未認証でも利用可能
+  - 更新系はBearerトークン必須
+
+### 4.2 `local` モード（E2E / ローカル受け入れ）
 - 保存先: `localStorage`
 - 保存キー: `book-reading-record.v1`
 - 初期値:
@@ -58,18 +70,18 @@
 - 保持期間:
   - ユーザーが削除するまで無期限
 
-## 5. データ破損と復旧
+## 5. データ破損と復旧（`local` モード）
 - JSON parse失敗時は破損データとして扱う
 - 破損データは `book-reading-record.v1.bak.<timestamp>` に退避する
 - 退避後、初期値で再初期化して起動する
 - UIに「復旧メッセージ」を表示する
 
-## 6. バージョン移行
+## 6. バージョン移行（`local` モード）
 - `StoragePayload.version` でスキーマ判定する
 - 自動移行不可の場合:
   - バックアップ退避
   - 初期値で再初期化
 
-## 7. 将来拡張（Phase 2）
-- Supabase移行時も `Book` / `ProgressLog` / `Reflection` の論理モデルは維持する
+## 7. 拡張方針
+- `supabase` / `local` のどちらでも `Book` / `ProgressLog` / `Reflection` の論理モデルは維持する
 - 既存ローカルデータのインポートは別タスクで設計する

--- a/docs/08.api-and-repository.md
+++ b/docs/08.api-and-repository.md
@@ -1,12 +1,14 @@
 # API And Repository Specification
 
 ## 1. 目的
-- ローカル開発（Phase 1）とSupabase移行（Phase 2）で共通利用するデータアクセス契約を定義する
+- `supabase` / `local` の両モードで共通利用するデータアクセス契約を定義する
 
-## 2. Phase 1 方針（ローカル開発）
-- HTTP APIは実装しない
+## 2. 現行アーキテクチャ
 - 画面はRepositoryインターフェース経由でデータ操作する
-- 永続化は `LocalStorageRepository` で実装する
+- ドライバーは `NEXT_PUBLIC_REPOSITORY_DRIVER` で切り替える（`supabase` / `local`）
+- `local` モードでは `LocalStorageRepository` を利用する
+- `supabase` モードでは `ApiRepository` を利用し、`/api/book-record/*` にアクセスする
+- API Route Handler は `PrismaBookRecordRepository` に委譲して Supabase DB を操作する
 
 ## 3. 必須 Repository I/F
 - `listBooks(): Promise<Book[]>`
@@ -20,11 +22,9 @@
 
 ## 4. エラー契約
 - バリデーション違反は業務エラーとして扱い、画面に表示可能なメッセージを返す
-- データ破損時は復旧処理を優先し、アプリ全体をクラッシュさせない
+- `local` モードでデータ破損時は復旧処理を優先し、アプリ全体をクラッシュさせない
 
-## 5. Phase 2 方針（Supabase）
-- 上記I/Fを `SupabaseRepository` で実装する
-- Next.js Route Handlerの追加は任意（必要時のみ）
+## 5. `supabase` モード方針
 - ユーザープロフィール機能が必要になるまでは単一ユーザー構成を維持する
 - 実装方針（2026-02-07）
   - クライアントは `ApiRepository` を利用する

--- a/docs/09.test-spec.md
+++ b/docs/09.test-spec.md
@@ -5,7 +5,7 @@
 
 ## 2. テスト対象
 - E2Eのみ（単体テストは作成しない）
-- 詳細ケース（Case 1-17）は `docs/04.e2e-cases.md` を参照
+- 詳細ケース（Case 1-18）は `docs/04.e2e-cases.md` を参照
 
 ## 3. 実行環境
 - ブラウザ: Chromium
@@ -13,7 +13,7 @@
 - コマンド:
   - `pnpm test:e2e`
 - 実行時設定:
-  - E2Eの受け入れケース（`docs/04`）は localStorage 前提で検証するため、PlaywrightのwebServerは `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で起動する
+  - E2Eの受け入れケース（`docs/04`）は `local` モード前提で検証するため、PlaywrightのwebServerは `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で起動する
 - 合格条件:
   - 全ケース成功（skipなし）
 


### PR DESCRIPTION
## Summary
This PR aligns project documentation with the current implementation where the app supports both `supabase` and `local` repository drivers.

## Issue
The codebase already runs with Supabase in normal operation (`ApiRepository` + `/api/book-record/*` + Prisma), but several docs still described a localStorage-only or "future Supabase" model.

## User Impact
Developers reading docs could misunderstand the actual runtime architecture, setup expectations, and test scope, which increases onboarding and maintenance risk.

## Root Cause
Documentation updates from the Supabase rollout were partially applied (for example in `front/README.md`) while core requirement and storage docs retained older Phase 1 assumptions.

## Fix
I updated the docs to clearly separate:
- Normal app operation: `NEXT_PUBLIC_REPOSITORY_DRIVER=supabase`
- E2E acceptance mode: `NEXT_PUBLIC_REPOSITORY_DRIVER=local`

Updated files:
- `README.md`
- `docs/02.ui-layout.md`
- `docs/03.requirements.md`
- `docs/04.e2e-cases.md`
- `docs/05.data-and-storage.md`
- `docs/08.api-and-repository.md`
- `docs/09.test-spec.md`

## Validation
- `cd front && pnpm lint` passed

## Notes
No application code behavior changes were included; this PR is documentation alignment only.
