### PR TITLE
fix: BookRecordテーブルにRLSポリシーを追加

### DIFF
--- a/docs/08.api-and-repository.md
+++ b/docs/08.api-and-repository.md
@@ -66,3 +66,28 @@
 - 閲覧系GET（`GET /api/book-record/books` / `GET /api/book-record/books/[id]` / `GET /api/book-record/books/[id]/progress-logs`）は未認証でも利用できる
 - 更新系（`POST /api/book-record/books` / `PATCH /api/book-record/books/[id]` / `POST /api/book-record/books/[id]/progress-logs` / `POST /api/book-record/books/[id]/reflection`）はBearerトークン必須で、未認証は `401` を返す
 - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` はこのリポジトリの `.env.local` では管理しない（Supabase Authプロジェクト側で管理する）
+
+## 9. RLSポリシー（Row Level Security）
+
+### 9.1 方針
+- `BookRecord*` テーブルはすべて RLS を有効にする
+- Prisma（`DATABASE_URL` 接続）はDBオーナーロールのため RLS をバイパスする
+- RLSポリシーは防御の深度（Defense-in-depth）として設定し、Supabase クライアント（`anon` / `authenticated` ロール）からの直接アクセスを制御する
+- ポリシー設計はアプリケーション層の認証契約（セクション8）と一致させる
+
+### 9.2 ポリシー定義
+
+| テーブル | SELECT | INSERT | UPDATE | DELETE |
+| --- | --- | --- | --- | --- |
+| `BookRecordBooks` | 誰でも可 | 認証必須 | 認証必須 | 認証必須 |
+| `BookRecordProgressLogs` | 誰でも可 | 認証必須 | — | 認証必須 |
+| `BookRecordReflections` | 誰でも可 | 認証必須 | 認証必須 | 認証必須 |
+
+- SELECT（`Public read`）: `USING (true)` — 未ログインでも閲覧可能
+- INSERT（`Auth write`）: `WITH CHECK (auth.uid() IS NOT NULL)` — ログイン必須
+- UPDATE（`Auth update`）: `USING / WITH CHECK (auth.uid() IS NOT NULL)` — ログイン必須
+- DELETE（`Auth delete`）: `USING (auth.uid() IS NOT NULL)` — ログイン必須
+- `BookRecordProgressLogs` は UPDATE ポリシーなし（進捗ログは追記のみで編集不可）
+
+### 9.3 適用日
+- 2026-03-22 に全ポリシーを Supabase SQL Editor で適用済み


### PR DESCRIPTION
## Summary
- BookRecordテーブル3つ（Books / ProgressLogs / Reflections）にRLS有効だがポリシーが未定義だった問題を修正
- Supabase SQL EditorでRLSポリシーを適用済み（SELECT: 公開、INSERT/UPDATE/DELETE: 認証必須）
- `docs/08.api-and-repository.md` にRLSポリシー仕様（セクション9）を追加

## 変更内容
- **DB側（Supabase）**: 11件のRLSポリシーを作成
  - `BookRecordBooks`: Public read / Auth write / Auth update / Auth delete
  - `BookRecordProgressLogs`: Public read / Auth write / Auth delete（UPDATEなし: 追記専用）
  - `BookRecordReflections`: Public read / Auth write / Auth update / Auth delete
- **ドキュメント**: `docs/08.api-and-repository.md` にセクション9（RLSポリシー）を追加

## 背景
- Prismaが`DATABASE_URL`のDBオーナーロールで接続するためRLSをバイパスしており、アプリ動作には影響なかった
- しかしSupabaseクライアント（anon/authenticatedロール）からの直接アクセスに対する防御の深度（Defense-in-depth）が欠けていた
- 同じDB内の他テーブル（Report等）にはRLSポリシーが存在しており、BookRecordだけ未設定だった

## Test plan
- [ ] Supabaseダッシュボードで3テーブルのRLSポリシーが反映されていることを確認
- [ ] アプリ（supabaseモード）で書籍の閲覧・登録・進捗記録・感想保存が正常動作すること
- [ ] 未ログイン状態でダッシュボード（`/`）と統計（`/stats`）が閲覧できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)