### PR TITLE
fix: CI Node.js 24へ更新、キャッシュエラーとレポートアップロード警告を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,19 @@ jobs:
         with:
           node-version: 24
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('front/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Node.js 20のdeprecation警告を解消するため `node-version` を `20 → 24` に変更
- E2Eテスト全pass時にPlaywrightレポートが生成されない場合でも警告が出ないよう `if-no-files-found: ignore` を追加
- `setup-node@v4` の `cache: pnpm` による `Path Validation Error` を解消するため、pnpmキャッシュを `actions/cache@v4` で明示的に管理する方式に変更

## 背景

mainへのpushで以下のエラー・警告が発生していた（Run ID: 23935689243）：

- `Path Validation Error: Path(s) specified in the action for caching do(es) not exist` → `setup-node@v4` のPost Runでキャッシュ保存失敗（failureとして記録）
- `No files were found with the provided path: front/playwright-report/` → テストが全pass時にレポートディレクトリが存在しないためアップロード失敗
- Node.js 20 actions deprecation警告（2026年6月より Node.js 24 強制移行）

## 変更内容

- `node-version: 24` に更新
- `setup-node@v4` から `cache: pnpm` および `cache-dependency-path` を削除（pnpm@10.x でのストアパス解決失敗を回避）
- `pnpm store path --silent` でpnpmストアパスを動的に取得し、`actions/cache@v4` で明示的にキャッシュ（キャッシュ機能を維持しつつ `Path Validation Error` を解消）
- `if-no-files-found: ignore` を追加

## Test plan

- [ ] CI が正常に完了することを確認（エラー・警告なし）
- [ ] E2E テストが全ケースpassすることを確認

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>