### PR TITLE
docs: テスト戦略を UT/IT/E2E の3層へ改訂（PR-A 方針確定）

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -13,6 +13,12 @@ globs: "front/prisma/**,front/src/lib/server/**"
 - 実行コマンド: `cd front && pnpm prisma:pull`。pull 前後で `pnpm prisma:validate` / `pnpm prisma:generate` を実行する。
 - テーブル定義の反映（push）は別プロジェクト側で実施する。反映完了後、このリポジトリで再度 `db pull` して同期する。
 
+### 例外: テストコンテナへの `db push`
+
+- **IT / E2E のテスト用 Postgres コンテナに限り `prisma db push` を許可する**。使い捨てコンテナへ `schema.prisma` を materialize する目的で、共有 Supabase プロジェクトには一切接続しない。
+- 実行は `DATABASE_URL` がテストコンテナを指すときのみ（`docker-compose.test.yml` 経由）。**共有 Supabase への `db push` / `migrate` は引き続き禁止**（禁止の本質は共有 DB を破壊しないこと）。
+- 詳細は `docs/08-test-specification.md`・`.claude/rules/testing.md` を参照。
+
 ## 命名規約
 
 - モデル名: PascalCase・単数形。本プロジェクトは物理テーブルに `BookRecord` 接頭辞を付与する。

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,15 +20,28 @@ globs:
 - ビジネスロジックをモックしない。モックは外部 I/O（HTTP通信、DB接続、ファイルシステム）のみ。
 - `toBeTruthy()` 等の曖昧なアサーションを避け、具体的な値で検証する。
 
-## テストツール
+## テスト層（3層構成）
 
-> 本プロジェクトは **E2E（Playwright）のみ**。単体テストは追加しない（`docs/01-business-requirements.md` §6 禁止事項）。
+> 詳細・受け入れケースは `docs/08-test-specification.md` を正とする。
 
-| テスト種別 | ツール |
-|-----------|--------|
-| E2E テスト | Playwright（Chromium・`local` モード / `front/e2e/`） |
-| スモークテスト | Playwright（起動確認・主要ページ表示） |
+| 層 | ツール | 対象 | 分離手段 |
+|---|---|---|---|
+| **UT（単体）** | Vitest（jsdom） | 純粋ロジック（`helpers`/`validation`）・`ApiRepository`・`LocalStorageRepository`・`auth-guard`・Route Handler・`parse*` | 外部 I/O のみモック |
+| **IT（結合）** | Vitest（node・`*.it.test.ts`・直列） | Route Handler + `PrismaBookRecordRepository` → 実 Postgres | DB コンテナ（docker-compose） |
+| **E2E / シナリオ** | Playwright（Chromium） | フルアプリの主要フロー | local レーン（高速） + supabase レーン（DB コンテナ・本番同等） |
 
-- 受け入れ基準は `docs/08-test-specification.md` の受け入れ E2E ケース（Case 1-18）を正とする。
-- 実行: `cd front && pnpm test:e2e`（webServer は `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で起動）。
-- セレクタは `data-testid` を優先し、文言ベース取得は補助的に用いる。
+- 実行: `pnpm test`（UT）/ `pnpm test:it`（IT）/ `pnpm test:e2e`（E2E）を `front/` で実行する。
+- セレクタ（E2E）は `data-testid` を優先し、文言ベース取得は補助的に用いる。
+- UT/IT/E2E の受け入れケースは `docs/08-test-specification.md` を正とする。
+
+## モック方針
+
+- **モックは外部 I/O 境界のみ**（`fetch` / `localStorage` / Supabase クライアント / Prisma）。ビジネスロジック（`validate*` / `computeWeeklySummary` / 並び順 / 完読判定等）はモックしない。
+- **UT**: 外部 I/O をモックして高速・隔離実行する。準正常・異常系（バリデーション・パース失敗・HTTP エラー）を厚くする主戦場。
+- **IT / E2E**: モックせず **DB コンテナ（実 Postgres）** に対して検証する。`supabase` の共有 DB は使わない。
+
+## DB コンテナ
+
+- IT・E2E(supabase レーン) は `docker-compose.test.yml` の使い捨て Postgres を使う。共有 Supabase プロジェクトには一切接続しない。
+- スキーマ投入は**テストコンテナ限定で `prisma db push`**（`.claude/rules/database.md` の例外規定を参照）。
+- E2E(supabase レーン)の認証は、本番で無効な env ゲート付きテストシームで通す（`docs/06-security-specification.md` 参照）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 | quality-gate.md | 全体 | 品質ゲート（セルフレビュー・設計/実装レビュー） |
 | documentation.md | 全体 | ドキュメント更新ルール |
 | git.md | 全体 | GitHub Flow・ブランチ命名・push 禁止物 |
-| testing.md | 全体 | テスト分類・原則・E2E(Playwright)ツール |
+| testing.md | 全体 | テスト分類・原則・3層(UT/IT/E2E)・モック/DBコンテナ方針 |
 | coding-standards.md | 全体 | コーディング規約（TypeScript strict・pnpm・ESLint/Prettier） |
 | error-handling.md | 全体 | エラーハンドリング方針（バリデーション・HTTP ステータス・統一レスポンス） |
 | security.md | 全体 | セキュリティ共通方針（認証・通信・インジェクション・シークレット） |

--- a/docs/01-business-requirements.md
+++ b/docs/01-business-requirements.md
@@ -61,8 +61,9 @@
 ## 6. 禁止事項
 
 - `base/` 配下の編集
-- このリポジトリから Prisma `db push` / `migrate` を実行すること
-- 単体テスト追加（E2E のみ。`docs/08-test-specification.md` 参照）
+- 共有 Supabase プロジェクトに対する Prisma `db push` / `migrate` の実行（テスト用の使い捨て Postgres コンテナへの `db push` は例外的に許可。`docs/08-test-specification.md`・`.claude/rules/database.md` 参照）
+
+> **方針変更（テスト戦略）**: 従来の「単体テスト禁止・E2E のみ」は撤回し、**UT（単体）/ IT（結合）/ E2E の3層**を導入する。詳細は `docs/08-test-specification.md`。
 
 ## 7. 関連ドキュメント
 

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -1,13 +1,19 @@
 # テスト仕様書（Test Specification）
 
-テスト戦略・実行条件・受け入れ E2E ケース・追加 E2E 設計を定義する。
+テスト戦略（UT / IT / E2E の3層）・実行条件・受け入れケースを定義する。
 
-> **優先順位**: 本書 §7 の受け入れ E2E ケース（Case 1-18）を**最優先の受け入れ基準**とする（`docs/02-requirements-specification.md` §4 参照）。
+> **方針変更（2026-07-06）**: 従来の「E2E のみ・単体テスト禁止」を撤回し、**UT（単体）/ IT（結合）/ E2E** の3層構成へ移行する。準正常系・異常系はこの拡充で厚くする。
+
+> **優先順位**: 本書 §7 の受け入れ E2E ケース（Case 1-18）を**最優先の受け入れ基準**とする（`docs/02-requirements-specification.md` §4 参照）。UT / IT はこれを支える下位層として位置づける。
 
 ## 目次
 
 - [1. 目的](#1-目的)
-- [2. テスト対象](#2-テスト対象)
+- [2. テスト戦略（3層）](#2-テスト戦略3層)
+  - [2.1 層構成](#21-層構成)
+  - [2.2 分類方針（正常/準正常/異常）](#22-分類方針正常準正常異常)
+  - [2.3 モック方針](#23-モック方針)
+  - [2.4 DB コンテナ](#24-db-コンテナ)
 - [3. 実行環境](#3-実行環境)
 - [4. 実行前処理](#4-実行前処理)
 - [5. セレクタ方針](#5-セレクタ方針)
@@ -43,21 +49,53 @@
   - [実装優先順位](#実装優先順位)
 
 ## 1. 目的
-- Playwright E2Eの実行条件と運用ルール、受け入れケースを定義する
+- UT / IT / E2E の3層のテスト戦略・実行条件・受け入れケースと、モック / DB コンテナの運用ルールを定義する
 
-## 2. テスト対象
-- E2Eのみ（単体テストは作成しない。`docs/01-business-requirements.md` §6 禁止事項）
-- 詳細ケース（Case 1-18）は本書 §7 を参照
+## 2. テスト戦略（3層）
+
+### 2.1 層構成
+
+| 層 | ツール | 対象 | 実行基盤 | ねらい |
+|---|---|---|---|---|
+| **UT（単体）** | Vitest（jsdom） | 純粋ロジック（`helpers`/`validation`）・`ApiRepository`・`LocalStorageRepository`・`auth-guard`・Route Handler・各 `parse*` | 外部 I/O のみモック | 高速・隔離。準正常/異常系を大量に |
+| **IT（結合）** | Vitest（node・`*.it.test.ts`・直列） | Route Handler + `PrismaBookRecordRepository` → 実 Postgres | DB コンテナ（docker-compose） | Prisma・トランザクション・認可の実挙動 |
+| **E2E / シナリオ** | Playwright（Chromium） | フルアプリの主要フロー | local レーン（高速）+ supabase レーン（DB コンテナ・本番同等） | 受け入れ・回帰 |
+
+- 実行コマンド: `pnpm test`（UT）/ `pnpm test:it`（IT）/ `pnpm test:e2e`（E2E）。すべて `front/` で実行する。
+- E2E は2レーン併存: `local`（`NEXT_PUBLIC_REPOSITORY_DRIVER=local`・現行 Case 1-18／§7）と `supabase`（DB コンテナ・API/Prisma/認証を含む本番同等シナリオ）。
+
+### 2.2 分類方針（正常/準正常/異常）
+
+- 分類定義と比率目安（正常 1 : 準正常+異常 2 以上）は `.claude/rules/testing.md` に従う。
+- **準正常系・異常系を各層で厚くする**（現状は正常系偏重のため）:
+  - **UT**: バリデーション境界値・上限超過・完読不整合、`parse*` の型不正/欠落/列挙外、`ApiRepository` の 401/404/500/JSON 崩れ、`parseStoragePayload` の破損/バージョン不一致
+  - **IT**: 未認証 POST → 401、存在しない id → 404、完読条件未達 → 400、`reflection` upsert 上書き、進捗＋書籍の `$transaction` 原子性
+  - **E2E(supabase)**: 未ログインで更新系がブロックされる → ログイン後成功、API 失敗時の画面ハンドリング
+
+### 2.3 モック方針
+
+- **モックは外部 I/O 境界のみ**（`fetch` / `localStorage` / Supabase クライアント / Prisma）。ビジネスロジック（`validate*` / `computeWeeklySummary` / 並び順 / 完読判定）はモックしない。
+- **UT** は外部 I/O をモックして隔離実行する。**IT / E2E** はモックせず実 Postgres（DB コンテナ）で検証する。
+
+### 2.4 DB コンテナ
+
+- IT・E2E(supabase レーン)は `docker-compose.test.yml` の**使い捨て Postgres** を使う。**共有 Supabase プロジェクトには一切接続しない**。
+- スキーマ投入は**テストコンテナ限定で `prisma db push`**（`.claude/rules/database.md` の例外規定）。`schema.prisma` を単一の真実とする。
+- E2E(supabase レーン)の認証は、本番で無効化される **env ゲート付きテストシーム**で通す（`docs/06-security-specification.md`。素の Postgres は Supabase Auth を持たないため）。
 
 ## 3. 実行環境
-- ブラウザ: Chromium
 - 実行ディレクトリ: `front/`
 - コマンド:
-  - `pnpm test:e2e`
+  - `pnpm test` — UT（Vitest / jsdom）
+  - `pnpm test:it` — IT（Vitest / node）。事前に `docker compose -f docker-compose.test.yml up -d` で Postgres を起動する
+  - `pnpm test:e2e` — E2E（Playwright / Chromium）
 - 実行時設定:
-  - E2Eの受け入れケース（§7）は `local` モード前提で検証するため、PlaywrightのwebServerは `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で起動する
+  - **UT**: 外部 I/O（`fetch` / `localStorage` / Supabase / Prisma）をモックし、DB・ネットワーク非依存で実行する
+  - **IT**: `DATABASE_URL` をテスト用 Postgres コンテナに向け、`globalSetup` で `prisma db push` してスキーマを投入。DB 状態を共有するため直列実行する
+  - **E2E(local レーン)**: §7 の受け入れケースは `NEXT_PUBLIC_REPOSITORY_DRIVER=local` で webServer を起動する
+  - **E2E(supabase レーン)**: `NEXT_PUBLIC_REPOSITORY_DRIVER=supabase` + DB コンテナで起動し、認証は env ゲート付きテストシームで通す
 - 合格条件:
-  - 全ケース成功（skipなし）
+  - UT / IT / E2E がすべて成功（未実装機能待ちの `test.skip` を除く）
 
 ## 4. 実行前処理
 - 各テスト開始時に `localStorage` を初期化する
@@ -244,7 +282,7 @@
 - 対象機能: 既存 Case 1〜18 で未カバーのシナリオ全般 + バックログ B1〜B4 対応 E2E
 - 対象ファイル: `front/e2e/book-app.spec.ts`（既存）、`front/e2e/smoke.spec.ts`（新規）、`front/e2e/backlog.spec.ts`（新規）
 - スタック: Next.js / TypeScript / Playwright (local モード)
-- 禁止事項: 単体テスト追加不可（`docs/01-business-requirements.md` §6）
+- 本節は **E2E 層**の追加設計に限定する。UT / IT の層構成・分類・モック/DB コンテナ方針は §2 を参照する。
 
 ### 現状の未カバー分析
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -81,7 +81,8 @@ flowchart TD
 - 反映後の手順
   - このリポジトリで再度 `db pull` を行い、最新定義に同期する
 - 禁止事項（このリポジトリ）
-  - `db push` / `migrate` の直接実行
+  - 共有 Supabase プロジェクトへの `db push` / `migrate` の直接実行
+  - 例外: IT / E2E のテスト用**使い捨て Postgres コンテナ**への `db push` は許可（共有 DB には接続しない。`docs/08-test-specification.md`・`.claude/rules/database.md`）
 
 ## 6. デプロイ / CI
 - デプロイ先は Vercel。


### PR DESCRIPTION
## 概要

テスト方針を刷新する取り組みの **PR-A（方針の文章化）**。従来の「単体テスト禁止・E2E のみ」を撤回し、**UT（単体）/ IT（結合）/ E2E** の3層構成を仕様として定義します。**コード変更はなく、ドキュメントのみ**です。以降の実装 PR（PR-B〜D）はこの仕様を基準にします。

## 確定した方針

- **UT**: Vitest(jsdom)。外部 I/O（`fetch`/`localStorage`/Supabase/Prisma）のみモック。準正常・異常系の主戦場。
- **IT**: Vitest(node・`*.it.test.ts`・直列)。`docker-compose.test.yml` の**使い捨て Postgres** に対し実 Prisma で Route Handler を検証。
- **E2E**: 2レーン併存 — `local`（高速・現行 Case 1-18）＋ `supabase`（DBコンテナ・API/Prisma/認証を含む本番同等）。
- 共有 Supabase プロジェクトには自動テストから**一切接続しない**。スキーマ投入は**テストコンテナ限定の `prisma db push`**（`schema.prisma` が単一の真実）。
- E2E(supabase) の認証は**本番で無効化される env ゲート付きテストシーム**で通す。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `docs/01` §6 | 単体テスト禁止を撤回。db push 禁止にテストコンテナ例外 |
| `docs/08` | §2 を3層戦略へ拡張・§3 に UT/IT 追加・§8 を E2E 限定明記・TOC 更新 |
| `docs/09` §5 | db push 禁止にテストコンテナ例外を反映 |
| `.claude/rules/testing.md` | E2E のみ → 3層＋モック/DBコンテナ方針 |
| `.claude/rules/database.md` | テストコンテナ限定 db push 例外 |
| `CLAUDE.md` | Rules テーブルの testing.md 説明を更新 |

## レビュー観点（設計レビュー）

実装 PR に進む前の**設計合意**が目的です。特に:
1. **`prisma db push`（テストコンテナ限定）の例外**を許容してよいか
2. **E2E supabase レーンの env ゲート認証シーム**（本番無効・テスト専用）の方針でよいか
3. ケース分類の増強ポイント（`docs/08` §2.2）に過不足がないか

## 次段階
- PR-B: UT 基盤（Vitest 導入）＋ 純粋ロジック/parse/repository の UT
- PR-C: IT 基盤（docker-compose.test.yml / vitest.it.config）＋ Route Handler×Prisma の IT
- PR-D: E2E supabase レーン（auth シーム）＋ CI 更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)