### PR TITLE
test(front): UT 土台を追加（純粋ロジック・Repository・auth-guard・Route Handler）

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prisma:generate": "node scripts/prisma-with-env-local.mjs generate",
     "prisma:pull": "node scripts/prisma-with-env-local.mjs db pull",
     "prisma:validate": "node scripts/prisma-with-env-local.mjs validate",
@@ -38,9 +40,11 @@
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsdoc": "^63.0.10",
+    "jsdom": "^29.1.1",
     "prettier": "^3.8.1",
     "prisma": "^6.16.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   }
 }

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       eslint-plugin-jsdoc:
         specifier: ^63.0.10
         version: 63.0.11(eslint@9.39.2(jiti@2.6.1))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -66,12 +69,30 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.32)(jsdom@29.1.1)(vite@8.1.3(@types/node@20.19.32)(jiti@2.6.1))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -140,14 +161,63 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@es-joy/jsdoccomment@0.88.0':
     resolution: {integrity: sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==}
@@ -194,6 +264,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -367,6 +446,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
 
@@ -437,6 +522,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+
   '@playwright/test@1.58.1':
     resolution: {integrity: sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==}
     engines: {node: '>=18'}
@@ -471,6 +559,98 @@ packages:
 
   '@prisma/get-platform@6.16.2':
     resolution: {integrity: sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==}
+
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -599,6 +779,15 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -787,6 +976,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -852,6 +1070,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -880,6 +1102,9 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -922,6 +1147,10 @@ packages:
 
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -968,11 +1197,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1002,6 +1239,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1057,6 +1297,10 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
@@ -1072,6 +1316,9 @@ packages:
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1229,9 +1476,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -1290,6 +1544,11 @@ packages:
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -1390,6 +1649,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -1484,6 +1747,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1545,6 +1811,15 @@ packages:
     resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
     engines: {node: '>=20.0.0'}
 
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1592,8 +1867,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1604,8 +1891,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -1616,8 +1915,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -1628,8 +1939,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -1640,8 +1963,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -1652,8 +1987,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   locate-path@6.0.0:
@@ -1667,6 +2012,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1676,6 +2025,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1700,6 +2052,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1778,6 +2135,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -1807,6 +2168,9 @@ packages:
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1835,6 +2199,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
@@ -1854,6 +2222,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -1919,6 +2291,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   reserved-identifiers@1.2.0:
     resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
     engines: {node: '>=18'}
@@ -1943,6 +2319,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1957,6 +2338,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2015,6 +2400,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2030,6 +2418,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2087,12 +2481,18 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -2102,12 +2502,35 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.6:
+    resolution: {integrity: sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==}
+
+  tldts@7.4.6:
+    resolution: {integrity: sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
   ts-api-utils@2.4.0:
@@ -2161,6 +2584,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -2172,6 +2599,106 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite@8.1.3:
+    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2194,6 +2721,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -2209,6 +2741,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2229,6 +2768,26 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2330,9 +2889,48 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -2342,6 +2940,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2401,6 +3004,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -2536,6 +3141,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.1.6': {}
 
   '@next/eslint-plugin-next@16.1.6':
@@ -2580,6 +3192,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/types@0.138.0': {}
+
   '@playwright/test@1.58.1':
     dependencies:
       playwright: 1.58.1
@@ -2618,6 +3232,57 @@ snapshots:
   '@prisma/get-platform@6.16.2':
     dependencies:
       '@prisma/debug': 6.16.2
+
+  '@rolldown/binding-android-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -2740,6 +3405,18 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2919,6 +3596,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@20.19.32)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@20.19.32)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3015,6 +3733,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -3034,6 +3754,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -3092,6 +3816,8 @@ snapshots:
 
   caniuse-lite@1.0.30001769: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3131,9 +3857,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3160,6 +3898,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -3210,6 +3950,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -3290,6 +4032,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -3549,7 +4293,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -3579,6 +4329,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3604,6 +4358,9 @@ snapshots:
       is-callable: 1.2.7
 
   fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
@@ -3709,6 +4466,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.6.0: {}
 
   iceberg-js@0.8.1: {}
@@ -3803,6 +4566,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3865,6 +4630,32 @@ snapshots:
 
   jsdoc-type-pratt-parser@7.2.0: {}
 
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -3904,34 +4695,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -3950,6 +4774,22 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -3960,6 +4800,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3969,6 +4811,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -3990,6 +4834,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.15: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -4075,6 +4921,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.3: {}
+
   ohash@2.0.11: {}
 
   optionator@0.9.4:
@@ -4110,6 +4958,10 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4125,6 +4977,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.5: {}
 
   pkg-types@2.3.0:
     dependencies:
@@ -4145,6 +4999,12 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4215,6 +5075,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   reserved-identifiers@1.2.0: {}
 
   resolve-from@4.0.0: {}
@@ -4234,6 +5096,27 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.1.4:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
 
   run-parallel@1.2.0:
     dependencies:
@@ -4257,6 +5140,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4354,6 +5241,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   spdx-exceptions@2.5.0: {}
@@ -4366,6 +5255,10 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -4439,9 +5332,13 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
 
@@ -4449,6 +5346,19 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.6: {}
+
+  tldts@7.4.6:
+    dependencies:
+      tldts-core: 7.4.6
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4458,6 +5368,14 @@ snapshots:
     dependencies:
       '@sindresorhus/base62': 1.0.0
       reserved-identifiers: 1.2.0
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.6
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -4531,6 +5449,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.28.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4564,6 +5484,62 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite@8.1.3(@types/node@20.19.32)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.32
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.10(@types/node@20.19.32)(jsdom@29.1.1)(vite@8.1.3(@types/node@20.19.32)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@20.19.32)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@20.19.32)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.32
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4610,9 +5586,18 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/front/src/app/api/book-record/books/[id]/__tests__/route.test.ts
+++ b/front/src/app/api/book-record/books/[id]/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+/**
+ * `books/[id]` の GET（取得・未認証可）/ PATCH（更新・認証必須）の Route Handler UT。
+ * エラークラスは `vi.hoisted` 内に定義し、`instanceof` の identity をルートと共有する。
+ */
+const H = vi.hoisted(() => {
+  class RepositoryValidationError extends Error {
+    readonly statusCode = 400;
+  }
+  class RepositoryNotFoundError extends Error {
+    readonly statusCode = 404;
+  }
+  class AuthGuardError extends Error {
+    readonly statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    RepositoryValidationError,
+    RepositoryNotFoundError,
+    AuthGuardError,
+    getBook: vi.fn(),
+    updateBook: vi.fn(),
+    requireAuthenticatedUser: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/prisma-book-record-repository", () => ({
+  PrismaBookRecordRepository: class {
+    getBook = H.getBook;
+    updateBook = H.updateBook;
+  },
+  RepositoryValidationError: H.RepositoryValidationError,
+  RepositoryNotFoundError: H.RepositoryNotFoundError,
+  isRepositoryError: (v: unknown) =>
+    v instanceof H.RepositoryValidationError || v instanceof H.RepositoryNotFoundError,
+}));
+
+vi.mock("@/lib/server/auth-guard", () => ({
+  requireAuthenticatedUser: H.requireAuthenticatedUser,
+  AuthGuardError: H.AuthGuardError,
+  isAuthGuardError: (v: unknown) => v instanceof H.AuthGuardError,
+}));
+
+import { GET, PATCH } from "../route";
+
+// `request.json()` だけを持つ最小の NextRequest。
+const jsonReq = (body: unknown) => ({ json: async () => body }) as unknown as NextRequest;
+// 動的ルートの params（Promise）を模した context。
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  H.getBook.mockReset();
+  H.updateBook.mockReset();
+  H.requireAuthenticatedUser.mockReset();
+  H.requireAuthenticatedUser.mockResolvedValue(undefined);
+});
+
+describe("GET /api/book-record/books/[id]（未認証可）", () => {
+  // --- 正常系 ---
+  it("存在する書籍を 200 で返す", async () => {
+    H.getBook.mockResolvedValue({ id: "b1" });
+    const res = await GET(jsonReq(null), ctx("b1"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ book: { id: "b1" } });
+    expect(H.getBook).toHaveBeenCalledWith("b1");
+  });
+
+  // --- 準正常系 ---
+  it("未検出（null）なら 404", async () => {
+    H.getBook.mockResolvedValue(null);
+    const res = await GET(jsonReq(null), ctx("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.getBook.mockRejectedValue(new Error("db down"));
+    const res = await GET(jsonReq(null), ctx("b1"));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/book-record/books/[id]（認証必須）", () => {
+  // --- 正常系 ---
+  it("認証済み・妥当なパッチで 200 と更新後書籍を返す", async () => {
+    H.updateBook.mockResolvedValue({ id: "b1", title: "new" });
+    const res = await PATCH(jsonReq({ title: "new" }), ctx("b1"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ book: { id: "b1", title: "new" } });
+    expect(H.updateBook).toHaveBeenCalledWith("b1", { title: "new" });
+  });
+
+  it("認識できないフィールドは無視して採用フィールドのみ渡す", async () => {
+    H.updateBook.mockResolvedValue({ id: "b1" });
+    await PATCH(jsonReq({ title: "new", bogus: 1, totalPages: "x" }), ctx("b1"));
+    expect(H.updateBook).toHaveBeenCalledWith("b1", { title: "new" });
+  });
+
+  // --- 準正常系 ---
+  it("未認証なら 401 で更新しない", async () => {
+    H.requireAuthenticatedUser.mockRejectedValue(new H.AuthGuardError("ログインが必要です。", 401));
+    const res = await PATCH(jsonReq({ title: "new" }), ctx("b1"));
+    expect(res.status).toBe(401);
+    expect(H.updateBook).not.toHaveBeenCalled();
+  });
+
+  it("ボディが非オブジェクトなら 400 で更新しない", async () => {
+    const res = await PATCH(jsonReq(null), ctx("b1"));
+    expect(res.status).toBe(400);
+    expect(H.updateBook).not.toHaveBeenCalled();
+  });
+
+  it("リポジトリが未検出エラーを投げれば 404 に写像する", async () => {
+    H.updateBook.mockRejectedValue(new H.RepositoryNotFoundError("対象の書籍が見つかりません。"));
+    const res = await PATCH(jsonReq({ title: "new" }), ctx("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("リポジトリが検証エラーを投げれば 400 に写像する", async () => {
+    H.updateBook.mockRejectedValue(new H.RepositoryValidationError("現在ページが不正です。"));
+    const res = await PATCH(jsonReq({ currentPage: -1 }), ctx("b1"));
+    expect(res.status).toBe(400);
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.updateBook.mockRejectedValue(new Error("db down"));
+    const res = await PATCH(jsonReq({ title: "new" }), ctx("b1"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/front/src/app/api/book-record/books/[id]/progress-logs/__tests__/route.test.ts
+++ b/front/src/app/api/book-record/books/[id]/progress-logs/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+/**
+ * `books/[id]/progress-logs` の GET（履歴・未認証可）/ POST（進捗追加・認証必須）の Route Handler UT。
+ * 負数ページ等の業務検証はリポジトリ層（実 Postgres）で行うため IT の担当。UT は
+ * ハンドラーの入力検証（型・列挙）と、リポジトリ検証エラーの 400 写像を検証する。
+ */
+const H = vi.hoisted(() => {
+  class RepositoryValidationError extends Error {
+    readonly statusCode = 400;
+  }
+  class RepositoryNotFoundError extends Error {
+    readonly statusCode = 404;
+  }
+  class AuthGuardError extends Error {
+    readonly statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    RepositoryValidationError,
+    RepositoryNotFoundError,
+    AuthGuardError,
+    listProgressLogs: vi.fn(),
+    addProgressLog: vi.fn(),
+    requireAuthenticatedUser: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/prisma-book-record-repository", () => ({
+  PrismaBookRecordRepository: class {
+    listProgressLogs = H.listProgressLogs;
+    addProgressLog = H.addProgressLog;
+  },
+  RepositoryValidationError: H.RepositoryValidationError,
+  RepositoryNotFoundError: H.RepositoryNotFoundError,
+  isRepositoryError: (v: unknown) =>
+    v instanceof H.RepositoryValidationError || v instanceof H.RepositoryNotFoundError,
+}));
+
+vi.mock("@/lib/server/auth-guard", () => ({
+  requireAuthenticatedUser: H.requireAuthenticatedUser,
+  AuthGuardError: H.AuthGuardError,
+  isAuthGuardError: (v: unknown) => v instanceof H.AuthGuardError,
+}));
+
+import { GET, POST } from "../route";
+
+// `request.json()` だけを持つ最小の NextRequest。
+const jsonReq = (body: unknown) => ({ json: async () => body }) as unknown as NextRequest;
+// 動的ルートの params（Promise）を模した context。
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+// 妥当な進捗ボディ。個別テストで一部を壊して準正常系を作る。
+const validBody = { page: 10, memo: "m", status: "reading" };
+
+beforeEach(() => {
+  H.listProgressLogs.mockReset();
+  H.addProgressLog.mockReset();
+  H.requireAuthenticatedUser.mockReset();
+  H.requireAuthenticatedUser.mockResolvedValue(undefined);
+});
+
+describe("GET /api/book-record/books/[id]/progress-logs（未認証可）", () => {
+  // --- 正常系 ---
+  it("履歴を 200 で返す", async () => {
+    H.listProgressLogs.mockResolvedValue([{ id: "p1" }]);
+    const res = await GET(jsonReq(null), ctx("b1"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ logs: [{ id: "p1" }] });
+    expect(H.listProgressLogs).toHaveBeenCalledWith("b1");
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.listProgressLogs.mockRejectedValue(new Error("db down"));
+    const res = await GET(jsonReq(null), ctx("b1"));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/book-record/books/[id]/progress-logs（認証必須）", () => {
+  // --- 正常系 ---
+  it("認証済み・妥当なボディで 201 と payload を返す", async () => {
+    H.addProgressLog.mockResolvedValue({ book: { id: "b1" }, log: { id: "p1" } });
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({ book: { id: "b1" }, log: { id: "p1" } });
+    expect(H.addProgressLog).toHaveBeenCalledWith("b1", expect.objectContaining({ page: 10 }));
+  });
+
+  // --- 準正常系 ---
+  it("未認証なら 401 で登録しない", async () => {
+    H.requireAuthenticatedUser.mockRejectedValue(new H.AuthGuardError("ログインが必要です。", 401));
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(401);
+    expect(H.addProgressLog).not.toHaveBeenCalled();
+  });
+
+  it("page が数値でなければ 400 で登録しない", async () => {
+    const res = await POST(jsonReq({ ...validBody, page: "10" }), ctx("b1"));
+    expect(res.status).toBe(400);
+    expect(H.addProgressLog).not.toHaveBeenCalled();
+  });
+
+  it("列挙外の status なら 400", async () => {
+    const res = await POST(jsonReq({ ...validBody, status: "unknown" }), ctx("b1"));
+    expect(res.status).toBe(400);
+    expect(H.addProgressLog).not.toHaveBeenCalled();
+  });
+
+  it("リポジトリが検証エラー（負数ページ等）を投げれば 400 に写像する", async () => {
+    H.addProgressLog.mockRejectedValue(new H.RepositoryValidationError("ページ数が不正です。"));
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(400);
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.addProgressLog.mockRejectedValue(new Error("db down"));
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/front/src/app/api/book-record/books/[id]/reflection/__tests__/route.test.ts
+++ b/front/src/app/api/book-record/books/[id]/reflection/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+/**
+ * `books/[id]/reflection` の POST（完読時感想の保存・認証必須）の Route Handler UT。
+ * エラークラスは `vi.hoisted` 内に定義し、`instanceof` の identity をルートと共有する。
+ */
+const H = vi.hoisted(() => {
+  class RepositoryValidationError extends Error {
+    readonly statusCode = 400;
+  }
+  class RepositoryNotFoundError extends Error {
+    readonly statusCode = 404;
+  }
+  class AuthGuardError extends Error {
+    readonly statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    RepositoryValidationError,
+    RepositoryNotFoundError,
+    AuthGuardError,
+    saveReflection: vi.fn(),
+    requireAuthenticatedUser: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/prisma-book-record-repository", () => ({
+  PrismaBookRecordRepository: class {
+    saveReflection = H.saveReflection;
+  },
+  RepositoryValidationError: H.RepositoryValidationError,
+  RepositoryNotFoundError: H.RepositoryNotFoundError,
+  isRepositoryError: (v: unknown) =>
+    v instanceof H.RepositoryValidationError || v instanceof H.RepositoryNotFoundError,
+}));
+
+vi.mock("@/lib/server/auth-guard", () => ({
+  requireAuthenticatedUser: H.requireAuthenticatedUser,
+  AuthGuardError: H.AuthGuardError,
+  isAuthGuardError: (v: unknown) => v instanceof H.AuthGuardError,
+}));
+
+import { POST } from "../route";
+
+// `request.json()` だけを持つ最小の NextRequest。
+const jsonReq = (body: unknown) => ({ json: async () => body }) as unknown as NextRequest;
+// 動的ルートの params（Promise）を模した context。
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+// 妥当な感想ボディ。各フィールドは空文字も許容されるため、型のみが検証対象。
+const validBody = { learning: "l", action: "a", quote: "q" };
+
+beforeEach(() => {
+  H.saveReflection.mockReset();
+  H.requireAuthenticatedUser.mockReset();
+  H.requireAuthenticatedUser.mockResolvedValue(undefined);
+});
+
+describe("POST /api/book-record/books/[id]/reflection（認証必須）", () => {
+  // --- 正常系 ---
+  it("認証済み・妥当なボディで 200 と更新後書籍を返す", async () => {
+    H.saveReflection.mockResolvedValue({ id: "b1" });
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ book: { id: "b1" } });
+    expect(H.saveReflection).toHaveBeenCalledWith("b1", validBody);
+  });
+
+  it("各フィールドが空文字でも 200（未記入は空文字で保存する仕様）", async () => {
+    H.saveReflection.mockResolvedValue({ id: "b1" });
+    const res = await POST(jsonReq({ learning: "", action: "", quote: "" }), ctx("b1"));
+    expect(res.status).toBe(200);
+  });
+
+  // --- 準正常系 ---
+  it("未認証なら 401 で保存しない", async () => {
+    H.requireAuthenticatedUser.mockRejectedValue(new H.AuthGuardError("ログインが必要です。", 401));
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(401);
+    expect(H.saveReflection).not.toHaveBeenCalled();
+  });
+
+  it("learning が文字列でなければ 400 で保存しない", async () => {
+    const res = await POST(jsonReq({ ...validBody, learning: 1 }), ctx("b1"));
+    expect(res.status).toBe(400);
+    expect(H.saveReflection).not.toHaveBeenCalled();
+  });
+
+  it("ボディが非オブジェクトなら 400", async () => {
+    const res = await POST(jsonReq(null), ctx("b1"));
+    expect(res.status).toBe(400);
+    expect(H.saveReflection).not.toHaveBeenCalled();
+  });
+
+  it("リポジトリが未検出エラーを投げれば 404 に写像する", async () => {
+    H.saveReflection.mockRejectedValue(new H.RepositoryNotFoundError("対象の書籍が見つかりません。"));
+    const res = await POST(jsonReq(validBody), ctx("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.saveReflection.mockRejectedValue(new Error("db down"));
+    const res = await POST(jsonReq(validBody), ctx("b1"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/front/src/app/api/book-record/books/__tests__/route.test.ts
+++ b/front/src/app/api/book-record/books/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+/**
+ * Route Handler UT のハーネス。外部 I/O 境界（Prisma リポジトリ・認証ガード）だけをモックし、
+ * ハンドラー自身の責務（認可分岐・入力検証・エラー→HTTP ステータス写像）を検証する。
+ *
+ * エラークラスは `vi.hoisted` 内に定義し、`vi.mock` ファクトリとテストが throw する側で
+ * 同一 identity を共有する（ルート内部の `instanceof` 判定が成立するため）。
+ */
+const H = vi.hoisted(() => {
+  class RepositoryValidationError extends Error {
+    readonly statusCode = 400;
+  }
+  class RepositoryNotFoundError extends Error {
+    readonly statusCode = 404;
+  }
+  class AuthGuardError extends Error {
+    readonly statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    RepositoryValidationError,
+    RepositoryNotFoundError,
+    AuthGuardError,
+    listBooks: vi.fn(),
+    createBook: vi.fn(),
+    requireAuthenticatedUser: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/prisma-book-record-repository", () => ({
+  PrismaBookRecordRepository: class {
+    listBooks = H.listBooks;
+    createBook = H.createBook;
+  },
+  RepositoryValidationError: H.RepositoryValidationError,
+  RepositoryNotFoundError: H.RepositoryNotFoundError,
+  isRepositoryError: (v: unknown) =>
+    v instanceof H.RepositoryValidationError || v instanceof H.RepositoryNotFoundError,
+}));
+
+vi.mock("@/lib/server/auth-guard", () => ({
+  requireAuthenticatedUser: H.requireAuthenticatedUser,
+  AuthGuardError: H.AuthGuardError,
+  isAuthGuardError: (v: unknown) => v instanceof H.AuthGuardError,
+}));
+
+import { GET, POST } from "../route";
+
+// `request.json()` だけを持つ最小の NextRequest を作る（body は任意の JSON 値）。
+const jsonReq = (body: unknown) => ({ json: async () => body }) as unknown as NextRequest;
+
+// 妥当な CreateBookInput ボディ。個別テストで一部を壊して準正常系を作る。
+const validBody = {
+  title: "t",
+  author: "a",
+  genre: "g",
+  format: "paper",
+  totalPages: 100,
+  tags: ["x"],
+  status: "reading",
+};
+
+beforeEach(() => {
+  H.listBooks.mockReset();
+  H.createBook.mockReset();
+  H.requireAuthenticatedUser.mockReset();
+  H.requireAuthenticatedUser.mockResolvedValue(undefined);
+});
+
+describe("GET /api/book-record/books（未認証可）", () => {
+  // --- 正常系 ---
+  it("一覧を取得して 200 で books を返す", async () => {
+    H.listBooks.mockResolvedValue([{ id: "b1" }]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ books: [{ id: "b1" }] });
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.listBooks.mockRejectedValue(new Error("db down"));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/book-record/books（認証必須）", () => {
+  // --- 正常系 ---
+  it("認証済み・妥当なボディで 201 と作成書籍を返す", async () => {
+    H.createBook.mockResolvedValue({ id: "b1", ...validBody });
+    const res = await POST(jsonReq(validBody));
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({ book: { id: "b1", ...validBody } });
+    expect(H.createBook).toHaveBeenCalledWith(expect.objectContaining({ title: "t" }));
+  });
+
+  // --- 準正常系 ---
+  it("未認証（認証ガードが 401 を投げる）なら 401 で作成しない", async () => {
+    H.requireAuthenticatedUser.mockRejectedValue(new H.AuthGuardError("ログインが必要です。", 401));
+    const res = await POST(jsonReq(validBody));
+    expect(res.status).toBe(401);
+    expect(H.createBook).not.toHaveBeenCalled();
+  });
+
+  it("ボディが非オブジェクトなら 400 で作成しない", async () => {
+    const res = await POST(jsonReq(null));
+    expect(res.status).toBe(400);
+    expect(H.createBook).not.toHaveBeenCalled();
+  });
+
+  it("必須フィールド欠落（totalPages なし）なら 400", async () => {
+    const noPages = { ...validBody, totalPages: undefined };
+    const res = await POST(jsonReq(noPages));
+    expect(res.status).toBe(400);
+    expect(H.createBook).not.toHaveBeenCalled();
+  });
+
+  it("列挙外の status なら 400", async () => {
+    const res = await POST(jsonReq({ ...validBody, status: "unknown" }));
+    expect(res.status).toBe(400);
+    expect(H.createBook).not.toHaveBeenCalled();
+  });
+
+  // --- 異常系 ---
+  it("リポジトリが想定外エラーなら 500", async () => {
+    H.createBook.mockRejectedValue(new Error("db down"));
+    const res = await POST(jsonReq(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/front/src/lib/__tests__/api-repository.test.ts
+++ b/front/src/lib/__tests__/api-repository.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { ApiRepository } from "../api-repository";
+
+// Supabase クライアントは外部 I/O 境界なのでモックする。
+const { mockGetSession } = vi.hoisted(() => ({ mockGetSession: vi.fn() }));
+vi.mock("../supabase/client", () => ({
+  isSupabaseAuthConfigured: true,
+  getSupabaseBrowserClient: () => ({ auth: { getSession: mockGetSession } }),
+}));
+
+// fetch のレスポンスを模したオブジェクトを作る。
+const res = (status: number, body: unknown, jsonThrows = false) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => {
+    if (jsonThrows) {
+      throw new Error("invalid json");
+    }
+    return body;
+  },
+});
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  mockGetSession.mockReset();
+  mockGetSession.mockResolvedValue({ data: { session: { access_token: "tok" } }, error: null });
+});
+
+const repo = new ApiRepository();
+
+describe("認証ヘッダ", () => {
+  // --- 正常系 ---
+  it("セッションがあれば Authorization: Bearer を付与する", async () => {
+    fetchMock.mockResolvedValue(res(200, { books: [] }));
+    await repo.listBooks();
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer tok");
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  // --- 準正常系 ---
+  it("未ログイン（セッションなし）では Authorization を付与しない", async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+    fetchMock.mockResolvedValue(res(200, { books: [] }));
+    await repo.listBooks();
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Headers).get("authorization")).toBeNull();
+  });
+
+  // --- 異常系 ---
+  it("セッション取得エラーは専用メッセージで失敗する", async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: { message: "boom" } });
+    await expect(repo.listBooks()).rejects.toThrow("ログインセッションの取得に失敗しました。");
+  });
+});
+
+describe("listBooks / getBook", () => {
+  // --- 正常系 ---
+  it("一覧のレスポンス books を返す", async () => {
+    fetchMock.mockResolvedValue(res(200, { books: [{ id: "b1" }] }));
+    expect(await repo.listBooks()).toEqual([{ id: "b1" }]);
+  });
+
+  it("getBook は book を返す", async () => {
+    fetchMock.mockResolvedValue(res(200, { book: { id: "b1" } }));
+    expect(await repo.getBook("b1")).toEqual({ id: "b1" });
+  });
+
+  // --- 準正常系 ---
+  it("getBook は 404 のとき null を返す", async () => {
+    fetchMock.mockResolvedValue(res(404, { message: "not found" }));
+    expect(await repo.getBook("missing")).toBeNull();
+  });
+
+  // --- 異常系 ---
+  it("getBook は 500 のとき例外を投げる（404 以外は握りつぶさない）", async () => {
+    fetchMock.mockResolvedValue(res(500, { message: "server error" }));
+    await expect(repo.getBook("b1")).rejects.toThrow("server error");
+  });
+});
+
+describe("createBook", () => {
+  // --- 正常系 ---
+  it("genre 未指定時は空文字で送信する", async () => {
+    fetchMock.mockResolvedValue(res(201, { book: { id: "b1" } }));
+    await repo.createBook({
+      title: "t",
+      author: "a",
+      format: "paper",
+      totalPages: 100,
+      tags: [],
+      status: "not_started",
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body as string).genre).toBe("");
+  });
+});
+
+describe("エラーメッセージ抽出", () => {
+  // --- 準正常系 ---
+  it("非 2xx の message をエラーメッセージに使う", async () => {
+    fetchMock.mockResolvedValue(res(400, { message: "入力が不正です。" }));
+    await expect(repo.listBooks()).rejects.toThrow("入力が不正です。");
+  });
+
+  // --- 異常系 ---
+  it("JSON でないエラーレスポンスは既定メッセージにフォールバックする", async () => {
+    fetchMock.mockResolvedValue(res(500, null, true));
+    await expect(repo.listBooks()).rejects.toThrow("データ操作に失敗しました。");
+  });
+});
+
+describe("searchBooks", () => {
+  // --- 正常系 ---
+  it("一覧を取得してクライアント側で部分一致フィルタする", async () => {
+    fetchMock.mockResolvedValue(
+      res(200, {
+        books: [
+          { id: "1", title: "Rust", author: "K", tags: ["rust"] },
+          { id: "2", title: "Go", author: "D", tags: ["go"] },
+        ],
+      })
+    );
+    const result = await repo.searchBooks("rust");
+    expect(result.map((b) => b.id)).toEqual(["1"]);
+  });
+});

--- a/front/src/lib/__tests__/helpers.test.ts
+++ b/front/src/lib/__tests__/helpers.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, it, expect } from "vitest";
+import {
+  computeWeeklySummary,
+  consumeRecoveryNotice,
+  createId,
+  getStatusOrder,
+  parseStoragePayload,
+  persistStoragePayload,
+  reflectionIsMissing,
+  sortBooks,
+  sortLogsAsc,
+  sortLogsDesc,
+} from "../helpers";
+import { RECOVERY_NOTICE_KEY, STORAGE_KEY, STORAGE_VERSION } from "../constants";
+import { Book, ProgressLog } from "../types";
+
+const makeBook = (overrides: Partial<Book> = {}): Book => ({
+  id: "b1",
+  title: "t",
+  author: "a",
+  format: "paper",
+  totalPages: 100,
+  currentPage: 0,
+  tags: [],
+  status: "reading",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const makeLog = (overrides: Partial<ProgressLog> = {}): ProgressLog => ({
+  id: "l1",
+  bookId: "b1",
+  page: 0,
+  status: "reading",
+  loggedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const daysAgoIso = (days: number): string => new Date(Date.now() - days * 86_400_000).toISOString();
+
+describe("sortBooks", () => {
+  // --- 正常系 ---
+  it("updatedAt 降順で並べ替える", () => {
+    const books = [
+      makeBook({ id: "old", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      makeBook({ id: "new", updatedAt: "2026-01-03T00:00:00.000Z" }),
+      makeBook({ id: "mid", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    expect(sortBooks(books).map((b) => b.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("updatedAt 同値なら createdAt 降順 → id 昇順で決定する", () => {
+    const at = "2026-01-05T00:00:00.000Z";
+    const books = [
+      makeBook({ id: "b", updatedAt: at, createdAt: "2026-01-01T00:00:00.000Z" }),
+      makeBook({ id: "a", updatedAt: at, createdAt: "2026-01-01T00:00:00.000Z" }),
+      makeBook({ id: "c", updatedAt: at, createdAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    expect(sortBooks(books).map((b) => b.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("元配列を破壊しない", () => {
+    const books = [makeBook({ id: "x" }), makeBook({ id: "y" })];
+    sortBooks(books);
+    expect(books.map((b) => b.id)).toEqual(["x", "y"]);
+  });
+});
+
+describe("sortLogsDesc / sortLogsAsc", () => {
+  const logs = [
+    makeLog({ id: "l1", loggedAt: "2026-01-01T00:00:00.000Z" }),
+    makeLog({ id: "l3", loggedAt: "2026-01-03T00:00:00.000Z" }),
+    makeLog({ id: "l2", loggedAt: "2026-01-02T00:00:00.000Z" }),
+  ];
+
+  it("降順（新しい順）で並べる", () => {
+    expect(sortLogsDesc(logs).map((l) => l.id)).toEqual(["l3", "l2", "l1"]);
+  });
+
+  it("昇順（古い順）で並べる", () => {
+    expect(sortLogsAsc(logs).map((l) => l.id)).toEqual(["l1", "l2", "l3"]);
+  });
+});
+
+describe("getStatusOrder", () => {
+  it("STATUS_ORDER のインデックスを返す", () => {
+    expect(getStatusOrder("not_started")).toBe(0);
+    expect(getStatusOrder("reading")).toBe(1);
+    expect(getStatusOrder("paused")).toBe(2);
+    expect(getStatusOrder("completed")).toBe(3);
+  });
+});
+
+describe("reflectionIsMissing", () => {
+  // --- 正常系 ---
+  it("感想が1項目でも埋まっていれば false", () => {
+    const book = makeBook({
+      reflection: { learning: "学び", action: "", quote: "", createdAt: daysAgoIso(0) },
+    });
+    expect(reflectionIsMissing(book)).toBe(false);
+  });
+
+  // --- 準正常系 ---
+  it("reflection 未登録なら true", () => {
+    expect(reflectionIsMissing(makeBook())).toBe(true);
+  });
+
+  it("3項目すべて空白のみなら true", () => {
+    const book = makeBook({
+      reflection: { learning: "  ", action: "\t", quote: "", createdAt: daysAgoIso(0) },
+    });
+    expect(reflectionIsMissing(book)).toBe(true);
+  });
+});
+
+describe("createId", () => {
+  it("空でない文字列を返し、呼び出しごとに異なる", () => {
+    const a = createId();
+    const b = createId();
+    expect(a.length).toBeGreaterThan(0);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("computeWeeklySummary", () => {
+  // --- 正常系 ---
+  it("直近7日の読了ページ・進捗回数・感想数を集計する", () => {
+    const books = [
+      makeBook({
+        reflection: { learning: "x", action: "", quote: "", createdAt: daysAgoIso(1) },
+      }),
+    ];
+    const logs = [
+      makeLog({ id: "in1", page: 10, loggedAt: daysAgoIso(2) }),
+      makeLog({ id: "in2", page: 30, loggedAt: daysAgoIso(1) }),
+      makeLog({ id: "out", page: 100, loggedAt: daysAgoIso(8) }),
+    ];
+    expect(computeWeeklySummary(books, logs)).toEqual({
+      readPages: 30,
+      progressCount: 2,
+      reflectionCount: 1,
+    });
+  });
+
+  // --- 準正常系 ---
+  it("読み戻し（負の差分）は読了ページに数えない", () => {
+    const logs = [
+      makeLog({ id: "a", page: 50, loggedAt: daysAgoIso(3) }),
+      makeLog({ id: "b", page: 20, loggedAt: daysAgoIso(1) }),
+    ];
+    expect(computeWeeklySummary([], logs).readPages).toBe(50);
+  });
+
+  it("ログなしはすべてゼロ", () => {
+    expect(computeWeeklySummary([], [])).toEqual({
+      readPages: 0,
+      progressCount: 0,
+      reflectionCount: 0,
+    });
+  });
+});
+
+describe("localStorage ペイロード（parse / persist / recovery）", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  // --- 正常系 ---
+  it("未設定時は初期値を返してキーを書き込む", () => {
+    const payload = parseStoragePayload();
+    expect(payload).toEqual({ version: STORAGE_VERSION, books: [], progressLogs: [] });
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("persist した内容を読み戻せる", () => {
+    persistStoragePayload({ version: STORAGE_VERSION, books: [makeBook()], progressLogs: [] });
+    expect(parseStoragePayload().books).toHaveLength(1);
+  });
+
+  // --- 異常系 ---
+  it("壊れた JSON はバックアップ退避のうえ初期化し、復旧通知を立てる", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{ broken json");
+    const payload = parseStoragePayload();
+
+    expect(payload.books).toEqual([]);
+    const backupKey = Object.keys(window.localStorage).find((k) =>
+      k.startsWith(`${STORAGE_KEY}.bak.`)
+    );
+    expect(backupKey).toBeDefined();
+    expect(window.localStorage.getItem(RECOVERY_NOTICE_KEY)).not.toBeNull();
+  });
+
+  it("バージョン不一致ペイロードは破損扱いで初期化する", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 999, books: [makeBook()], progressLogs: [] })
+    );
+    expect(parseStoragePayload().books).toEqual([]);
+  });
+
+  it("books が配列でないペイロードは破損扱いで初期化する", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: STORAGE_VERSION, books: "nope", progressLogs: [] })
+    );
+    expect(parseStoragePayload().books).toEqual([]);
+  });
+
+  it("consumeRecoveryNotice は1回だけ値を返し、以後は null", () => {
+    window.localStorage.setItem(RECOVERY_NOTICE_KEY, "2026-07-06T00:00:00.000Z");
+    expect(consumeRecoveryNotice()).toBe("2026-07-06T00:00:00.000Z");
+    expect(consumeRecoveryNotice()).toBeNull();
+  });
+});

--- a/front/src/lib/__tests__/local-storage-repository.test.ts
+++ b/front/src/lib/__tests__/local-storage-repository.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, it, expect } from "vitest";
+import { LocalStorageRepository } from "../local-storage-repository";
+import { CreateBookInput } from "../types";
+
+const baseInput: CreateBookInput = {
+  title: "  リーダブルコード  ",
+  author: "  Boswell  ",
+  genre: "  技術書  ",
+  format: "paper",
+  totalPages: 100,
+  tags: ["clean"],
+  status: "reading",
+};
+
+let repo: LocalStorageRepository;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  repo = new LocalStorageRepository();
+});
+
+describe("createBook", () => {
+  // --- 正常系 ---
+  it("currentPage=0 で作成し、title/author/genre を trim する", async () => {
+    const book = await repo.createBook(baseInput);
+    expect(book.currentPage).toBe(0);
+    expect(book.title).toBe("リーダブルコード");
+    expect(book.author).toBe("Boswell");
+    expect(book.genre).toBe("技術書");
+    expect(book.status).toBe("reading");
+    expect(book.id.length).toBeGreaterThan(0);
+  });
+
+  it("空 genre は undefined になる", async () => {
+    const book = await repo.createBook({ ...baseInput, genre: "   " });
+    expect(book.genre).toBeUndefined();
+  });
+
+  it("作成した書籍は一覧・取得で参照できる", async () => {
+    const created = await repo.createBook(baseInput);
+    expect(await repo.listBooks()).toHaveLength(1);
+    expect((await repo.getBook(created.id))?.id).toBe(created.id);
+  });
+
+  it("存在しない ID の取得は null", async () => {
+    expect(await repo.getBook("missing")).toBeNull();
+  });
+});
+
+describe("updateBook", () => {
+  // --- 正常系 ---
+  it("currentPage が総ページ到達で completed を自動確定し completedAt を付与する", async () => {
+    const book = await repo.createBook(baseInput);
+    const updated = await repo.updateBook(book.id, { currentPage: 100 });
+    expect(updated.status).toBe("completed");
+    expect(updated.completedAt).toBeDefined();
+  });
+
+  it("再読（reading へ戻す）で completedAt を解除し reflection は保持する", async () => {
+    const book = await repo.createBook(baseInput);
+    await repo.updateBook(book.id, { currentPage: 100 });
+    await repo.saveReflection(book.id, { learning: "学び", action: "", quote: "" });
+
+    const reread = await repo.updateBook(book.id, {
+      status: "reading",
+      currentPage: 0,
+      completedAt: undefined,
+    });
+    expect(reread.status).toBe("reading");
+    expect(reread.completedAt).toBeUndefined();
+    expect(reread.reflection?.learning).toBe("学び");
+  });
+
+  // --- 準正常系 ---
+  it("総ページ未満で completed 指定は保存エラー", async () => {
+    const book = await repo.createBook(baseInput);
+    await expect(
+      repo.updateBook(book.id, { status: "completed", currentPage: 50 })
+    ).rejects.toThrow("完読にするには到達ページを総ページ以上にしてください。");
+  });
+
+  // --- 異常系 ---
+  it("存在しない書籍の更新はエラー", async () => {
+    await expect(repo.updateBook("missing", {})).rejects.toThrow("対象の書籍が見つかりません。");
+  });
+});
+
+describe("addProgressLog", () => {
+  // --- 正常系 ---
+  it("進捗を記録して currentPage を更新し、履歴を1件追加する", async () => {
+    const book = await repo.createBook(baseInput);
+    const { book: updated } = await repo.addProgressLog(book.id, { page: 50, status: "reading" });
+    expect(updated.currentPage).toBe(50);
+    expect(await repo.listProgressLogs(book.id)).toHaveLength(1);
+  });
+
+  it("到達ページが総ページ以上なら completed を自動確定する", async () => {
+    const book = await repo.createBook(baseInput);
+    const { book: updated } = await repo.addProgressLog(book.id, { page: 100, status: "reading" });
+    expect(updated.status).toBe("completed");
+  });
+
+  // --- 準正常系 ---
+  it("総ページ未満で completed 指定は保存エラー", async () => {
+    const book = await repo.createBook(baseInput);
+    await expect(repo.addProgressLog(book.id, { page: 50, status: "completed" })).rejects.toThrow(
+      "完読にするには到達ページを総ページ以上にしてください。"
+    );
+  });
+
+  // --- 異常系 ---
+  it("存在しない書籍への進捗記録はエラー", async () => {
+    await expect(repo.addProgressLog("missing", { page: 1, status: "reading" })).rejects.toThrow(
+      "対象の書籍が見つかりません。"
+    );
+  });
+});
+
+describe("saveReflection", () => {
+  // --- 正常系 ---
+  it("感想を保存し、上書き時も作成日時を保持する", async () => {
+    const book = await repo.createBook(baseInput);
+    const first = await repo.saveReflection(book.id, { learning: "初回", action: "", quote: "" });
+    const createdAt = first.reflection?.createdAt;
+
+    const second = await repo.saveReflection(book.id, {
+      learning: "上書き",
+      action: "",
+      quote: "",
+    });
+    expect(second.reflection?.learning).toBe("上書き");
+    expect(second.reflection?.createdAt).toBe(createdAt);
+  });
+
+  // --- 準正常系 ---
+  it("上限超過の感想は保存エラー", async () => {
+    const book = await repo.createBook(baseInput);
+    await expect(
+      repo.saveReflection(book.id, { learning: "a".repeat(5001), action: "", quote: "" })
+    ).rejects.toThrow("学びは5000文字以内で入力してください。");
+  });
+
+  // --- 異常系 ---
+  it("存在しない書籍への感想保存はエラー", async () => {
+    await expect(
+      repo.saveReflection("missing", { learning: "", action: "", quote: "" })
+    ).rejects.toThrow("対象の書籍が見つかりません。");
+  });
+});
+
+describe("searchBooks", () => {
+  beforeEach(async () => {
+    await repo.createBook({ ...baseInput, title: "Rust入門", author: "Klabnik", tags: ["rust"] });
+    await repo.createBook({ ...baseInput, title: "Go言語", author: "Donovan", tags: ["go"] });
+  });
+
+  // --- 正常系 ---
+  it("著者の部分一致で絞り込む", async () => {
+    const result = await repo.searchBooks("klab");
+    expect(result.map((b) => b.title)).toEqual(["Rust入門"]);
+  });
+
+  it("タグの部分一致で絞り込む", async () => {
+    expect((await repo.searchBooks("go")).map((b) => b.title)).toContain("Go言語");
+  });
+
+  it("空クエリは全件返す", async () => {
+    expect(await repo.searchBooks("  ")).toHaveLength(2);
+  });
+
+  // --- 準正常系 ---
+  it("一致しないクエリは空配列", async () => {
+    expect(await repo.searchBooks("zzz-none")).toEqual([]);
+  });
+});

--- a/front/src/lib/__tests__/validation.test.ts
+++ b/front/src/lib/__tests__/validation.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeTags,
+  validateBookForm,
+  validateProgressForm,
+  validateReflection,
+} from "../validation";
+
+const validBookInput = {
+  title: "リーダブルコード",
+  author: "Dustin Boswell",
+  genre: "技術書",
+  totalPages: 260,
+  tags: ["programming", "clean-code"],
+  status: "not_started" as const,
+};
+
+describe("normalizeTags", () => {
+  // --- 正常系 ---
+  it("カンマ区切りを trim して配列化する", () => {
+    expect(normalizeTags("react, typescript ,  next ")).toEqual(["react", "typescript", "next"]);
+  });
+
+  // --- 準正常系 ---
+  it("空要素・空白のみ要素を除去する", () => {
+    expect(normalizeTags("a,,  , b")).toEqual(["a", "b"]);
+  });
+
+  it("空文字入力は空配列を返す", () => {
+    expect(normalizeTags("")).toEqual([]);
+  });
+});
+
+describe("validateBookForm", () => {
+  // --- 正常系 ---
+  it("妥当な入力はエラーなし", () => {
+    expect(validateBookForm(validBookInput)).toEqual({});
+  });
+
+  it("境界値（title 1文字・totalPages 1・tags 10件）を許容する", () => {
+    const errors = validateBookForm({
+      ...validBookInput,
+      title: "a",
+      totalPages: 1,
+      tags: Array.from({ length: 10 }, (_, i) => `t${i}`),
+    });
+    expect(errors).toEqual({});
+  });
+
+  it("上限境界（title 200・author 120・genre 80・totalPages 100000）を許容する", () => {
+    const errors = validateBookForm({
+      ...validBookInput,
+      title: "a".repeat(200),
+      author: "b".repeat(120),
+      genre: "c".repeat(80),
+      totalPages: 100000,
+    });
+    expect(errors).toEqual({});
+  });
+
+  // --- 準正常系 ---
+  it("title が空ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, title: "   " }).title).toBe(
+      "タイトルは1〜200文字で入力してください。"
+    );
+  });
+
+  it("title が 201 文字ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, title: "a".repeat(201) }).title).toBeDefined();
+  });
+
+  it("author が空・121 文字ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, author: "" }).author).toBeDefined();
+    expect(validateBookForm({ ...validBookInput, author: "a".repeat(121) }).author).toBeDefined();
+  });
+
+  it("genre が 81 文字ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, genre: "g".repeat(81) }).genre).toBe(
+      "ジャンルは80文字以内で入力してください。"
+    );
+  });
+
+  it("totalPages が 0・100001 ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, totalPages: 0 }).totalPages).toBeDefined();
+    expect(validateBookForm({ ...validBookInput, totalPages: 100001 }).totalPages).toBeDefined();
+  });
+
+  it("totalPages が非整数ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, totalPages: 12.5 }).totalPages).toBeDefined();
+  });
+
+  it("tags が 11 件ならエラー", () => {
+    const errors = validateBookForm({
+      ...validBookInput,
+      tags: Array.from({ length: 11 }, (_, i) => `t${i}`),
+    });
+    expect(errors.tags).toBe("タグは最大10件までです。");
+  });
+
+  it("tag が 31 文字ならエラー", () => {
+    expect(validateBookForm({ ...validBookInput, tags: ["a".repeat(31)] }).tags).toBe(
+      "タグは1〜30文字で入力してください。"
+    );
+  });
+
+  // --- 異常系 ---
+  it("初期ステータスに completed は指定できない", () => {
+    expect(validateBookForm({ ...validBookInput, status: "completed" }).status).toBe(
+      "初期ステータスに完読は指定できません。"
+    );
+  });
+});
+
+describe("validateProgressForm", () => {
+  const base = { page: 100, totalPages: 260, status: "reading" as const, memo: "" };
+
+  // --- 正常系 ---
+  it("妥当な進捗入力はエラーなし", () => {
+    expect(validateProgressForm(base)).toEqual({});
+  });
+
+  it("page が総ページ以上かつ completed は整合（エラーなし）", () => {
+    expect(validateProgressForm({ ...base, page: 260, status: "completed" })).toEqual({});
+  });
+
+  // --- 準正常系 ---
+  it("page が負数ならエラー", () => {
+    expect(validateProgressForm({ ...base, page: -1 }).page).toBe(
+      "到達ページは0〜100000の整数で入力してください。"
+    );
+  });
+
+  it("page が非整数・100001 ならエラー", () => {
+    expect(validateProgressForm({ ...base, page: 3.5 }).page).toBeDefined();
+    expect(validateProgressForm({ ...base, page: 100001 }).page).toBeDefined();
+  });
+
+  it("memo が 5001 文字ならエラー", () => {
+    expect(validateProgressForm({ ...base, memo: "m".repeat(5001) }).memo).toBeDefined();
+  });
+
+  // --- 異常系 ---
+  it("page が総ページ未満なのに completed を選ぶと状態エラー", () => {
+    expect(validateProgressForm({ ...base, page: 100, status: "completed" }).status).toBe(
+      "完読にするには到達ページを総ページ以上にしてください。"
+    );
+  });
+});
+
+describe("validateReflection", () => {
+  const base = { learning: "", action: "", quote: "" };
+
+  // --- 正常系 ---
+  it("3項目すべて空でもエラーなし（空入力可）", () => {
+    expect(validateReflection(base)).toEqual({});
+  });
+
+  it("上限 5000 文字ちょうどはエラーなし", () => {
+    expect(validateReflection({ ...base, learning: "a".repeat(5000) })).toEqual({});
+  });
+
+  // --- 準正常系 ---
+  it("learning/action/quote が 5001 文字ならそれぞれエラー", () => {
+    expect(validateReflection({ ...base, learning: "a".repeat(5001) }).learning).toBeDefined();
+    expect(validateReflection({ ...base, action: "a".repeat(5001) }).action).toBeDefined();
+    expect(validateReflection({ ...base, quote: "a".repeat(5001) }).quote).toBeDefined();
+  });
+});

--- a/front/src/lib/server/__tests__/auth-guard.test.ts
+++ b/front/src/lib/server/__tests__/auth-guard.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// Supabase クライアント（外部 I/O）をモックし、トークン検証結果を制御する。
+const { mockGetUser } = vi.hoisted(() => ({ mockGetUser: vi.fn() }));
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ auth: { getUser: mockGetUser } }),
+}));
+
+// authorization ヘッダだけを持つ最小の NextRequest を作る。
+const reqWith = (authorization: string | null) =>
+  ({
+    headers: { get: (key: string) => (key === "authorization" ? authorization : null) },
+  }) as unknown as NextRequest;
+
+// env の有無を切り替えて auth-guard を再読み込みする（serverAuthClient は import 時に決まるため）。
+const loadGuard = async (withEnv: boolean) => {
+  vi.resetModules();
+  if (withEnv) {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  } else {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  }
+  return import("../auth-guard");
+};
+
+beforeEach(() => {
+  mockGetUser.mockReset();
+});
+
+describe("requireAuthenticatedUser", () => {
+  // --- 正常系 ---
+  it("有効な Bearer トークンでユーザーを解決できれば通過する", async () => {
+    const guard = await loadGuard(true);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+    await expect(guard.requireAuthenticatedUser(reqWith("Bearer valid"))).resolves.toBeUndefined();
+  });
+
+  // --- 準正常系 ---
+  it("Authorization ヘッダなしは 401", async () => {
+    const guard = await loadGuard(true);
+    await expect(guard.requireAuthenticatedUser(reqWith(null))).rejects.toMatchObject({
+      statusCode: 401,
+    });
+  });
+
+  it("Bearer 以外のスキームは 401", async () => {
+    const guard = await loadGuard(true);
+    await expect(guard.requireAuthenticatedUser(reqWith("Basic abc"))).rejects.toMatchObject({
+      statusCode: 401,
+    });
+  });
+
+  it("トークンが空白のみは 401", async () => {
+    const guard = await loadGuard(true);
+    await expect(guard.requireAuthenticatedUser(reqWith("Bearer    "))).rejects.toMatchObject({
+      statusCode: 401,
+    });
+  });
+
+  it("トークン検証でユーザーを解決できなければ 401", async () => {
+    const guard = await loadGuard(true);
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: "invalid" } });
+    await expect(guard.requireAuthenticatedUser(reqWith("Bearer bad"))).rejects.toMatchObject({
+      statusCode: 401,
+    });
+  });
+
+  // --- 異常系 ---
+  it("環境変数が不足していれば 500", async () => {
+    const guard = await loadGuard(false);
+    await expect(guard.requireAuthenticatedUser(reqWith("Bearer valid"))).rejects.toMatchObject({
+      statusCode: 500,
+    });
+  });
+});

--- a/front/src/test/server-only-stub.ts
+++ b/front/src/test/server-only-stub.ts
@@ -1,0 +1,3 @@
+// `server-only` の UT 用スタブ。vitest.config.ts の alias から解決される。
+// 本番/ビルド時は本物の `server-only` がクライアント混入を検出するが、UT では no-op でよい。
+export {};

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+// UT（単体）専用構成。外部 I/O をモックし DB・ネットワーク非依存で実行する。
+// IT（*.it.test.ts）は DB 依存のため別構成（PR-C で vitest.it.config.ts を追加）で分離する。
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", "e2e/**", "src/**/*.it.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      // サーバー専用ガード（import "server-only"）は UT 実行環境では不要なため空スタブへ差し替える。
+      "server-only": path.resolve(__dirname, "./src/test/server-only-stub.ts"),
+    },
+  },
+});


### PR DESCRIPTION
## 概要

テスト戦略 UT/IT/E2E 3層構成のうち、**UT（単体）層の土台**を新設する（PR-B）。
Vitest（jsdom）で外部 I/O 境界（`fetch` / `localStorage` / Supabase / Prisma）のみをモックし、
準正常系・異常系を厚く検証する。IT（実 Postgres）・E2E は本 PR のスコープ外。

## 変更点

- **純粋ロジック**: `helpers`（集計・並び順・完読判定）/ `validation`（境界値・上限超過）
- **Repository**: `ApiRepository`（認証ヘッダ・401/404/500・JSON 崩れ）/ `LocalStorageRepository`（破損データ復旧・バージョン不一致）
- **サーバー**: `auth-guard`（Bearer 認証ガード 401/500）/ **Route Handler 4本**（books・[id]・progress-logs・reflection — 認可401 / 入力検証400 / 未検出404 / リポジトリエラー→HTTP 写像 / 500）
- **基盤**: `vitest.config.ts`（jsdom・`server-only` スタブ・IT 除外）/ `pnpm test` 依存追加

## 確認してほしい点

- `cd front && pnpm test` → **9ファイル / 112テスト passed**
- `pnpm exec eslint` / `pnpm exec tsc --noEmit` → クリーン
- モック方針: ビジネスロジックはモックせず外部 I/O 境界のみモック（testing.md 準拠）
- 正常系1 : 異常系2 以上の比率で構成しているか

## ドキュメント影響

`docs/08-test-specification.md` §2.1 は Route Handler ほかを既に UT 対象として明記済み。
本 PR は仕様どおりの実装追加であり契約変更を伴わないため、ドキュメント更新は不要と判断（documentation.md の opt-out）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)