### PR TITLE
test(it): IT（結合）基盤の追加と CI の3層＋静的ゲート化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: front/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -67,8 +65,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: front/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -92,8 +88,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: front/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -128,8 +122,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: front/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: CI
 
 on:
   push:
@@ -14,13 +14,12 @@ on:
       - ".github/**/*.md"
 
 jobs:
-  e2e:
+  # 静的ゲート: lint / 型 / フォーマット。最速で全 PR の門番になる。
+  static:
     runs-on: ubuntu-latest
-
     defaults:
       run:
         working-directory: front
-
     steps:
       - uses: actions/checkout@v4
 
@@ -31,19 +30,106 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: pnpm
+          cache-dependency-path: front/pnpm-lock.yaml
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Cache pnpm store
-        uses: actions/cache@v4
+      # 型チェック（tsc）は Prisma Client の型を要求するため generate しておく。
+      - name: Generate Prisma Client
+        run: pnpm exec prisma generate
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/placeholder?schema=public
+
+      - name: Format check
+        run: pnpm format:check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+  # UT（単体・jsdom・外部 I/O モック）。DB 不要で高速。
+  ut:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('front/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          package_json_file: front/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: front/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run UT
+        run: pnpm test
+
+  # IT（結合・node・実 Postgres）。docker-compose.test.yml の使い捨てコンテナに対して実行する。
+  it:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: front/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: front/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # IT はテストコンテナへ db push し @prisma/client を実行時 import するため generate が必要。
+      - name: Generate Prisma Client
+        run: pnpm exec prisma generate
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/book_record_test?schema=public
+
+      # test:it が docker compose 起動(--wait) → prisma db push → Vitest まで一括で行う。
+      - name: Run IT
+        run: pnpm test:it
+
+      - name: Stop test DB
+        if: always()
+        run: pnpm test:it:down
+
+  # E2E / シナリオ（Playwright / Chromium・local レーン）。受け入れ Case 1-18。
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: front/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: front/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Book Reading Record Web App
 
-[![E2E Tests](https://github.com/kojikawazu/book-reading-record-web-app/actions/workflows/ci.yml/badge.svg)](https://github.com/kojikawazu/book-reading-record-web-app/actions/workflows/ci.yml)
+[![CI](https://github.com/kojikawazu/book-reading-record-web-app/actions/workflows/ci.yml/badge.svg)](https://github.com/kojikawazu/book-reading-record-web-app/actions/workflows/ci.yml)
 ![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=next.js&logoColor=white)
 ![React](https://img.shields.io/badge/React-19-149ECA?logo=react&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)
@@ -122,10 +122,12 @@ cd front
 pnpm format:check   # Prettier（整形チェック）
 pnpm lint           # ESLint
 pnpm build          # 本番ビルド（内部で prisma generate を実行）
+pnpm test           # Vitest UT（単体）
+pnpm test:it        # Vitest IT（結合・DB コンテナで実 Postgres・要 Docker）
 pnpm test:e2e       # Playwright E2E（local モードで起動）
 ```
 
-> `pnpm build` / `pnpm test:e2e:install` の詳細・E2E のUIモード等は [front/README.md](front/README.md) を参照。
+> `pnpm build` / `pnpm test:e2e:install` の詳細・IT の DB コンテナ運用・E2E のUIモード等は [front/README.md](front/README.md) を参照。
 > 開発フロー（ブランチ運用・テスト必須・PR ルール）は [.claude/rules/](.claude/rules/) にまとまっています。
 
 ## Deploy

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -87,4 +87,9 @@ flowchart TD
 ## 6. デプロイ / CI
 - デプロイ先は Vercel。
 - `front/vercel.json` の `ignoreCommand`（`scripts/vercel-ignore-docs.sh`）で、`docs/` のみ変更されたコミットは Vercel ビルドをスキップする。`front/` 配下やその他ファイルの変更がある場合は通常どおりビルドする。
-- GitHub Actions（`.github/workflows/ci.yml`）は `docs/**` のみの変更時に CI をスキップする。
+- GitHub Actions（`.github/workflows/ci.yml`）は `docs/**` / `*.md` のみの変更時に CI をスキップする。
+- CI は4ジョブ構成（並列実行）:
+  - `static` — `format:check` / `lint` / `tsc --noEmit`（静的ゲート・最速の門番）
+  - `ut` — `pnpm test`（UT・jsdom・DB 不要）
+  - `it` — `pnpm test:it`（IT・`docker-compose.test.yml` の使い捨て Postgres で実行。共有 DB 非接続）
+  - `e2e` — `pnpm test:e2e`（Playwright / Chromium・local レーン・受け入れ Case 1-18）

--- a/front/README.md
+++ b/front/README.md
@@ -41,6 +41,17 @@ pnpm dev
 pnpm test:e2e:install   # Playwright（Chromium）を取得
 ```
 
+### 4. IT（結合テスト）を実行する場合のみ
+
+IT は使い捨て Postgres コンテナ（`docker-compose.test.yml`・`localhost:5433`）に対して実行します。**Docker が必要**です。共有 Supabase には一切接続しません。
+
+```bash
+pnpm test:it        # コンテナ起動(--wait) → prisma db push → Vitest(node) 実行
+pnpm test:it:down   # テスト DB コンテナを破棄
+```
+
+> 接続先は `vitest.it.config.ts` の既定値（`localhost:5433`）を使うため、`.env.test` は無くても動きます（ローカル上書き用に `.env.test` を置くことも可能）。
+
 ## Environment Variables
 
 `NEXT_PUBLIC_REPOSITORY_DRIVER` が未設定の場合、Supabase の URL/キーが揃っていれば `supabase`、なければ `local` を自動選択します（`src/lib/repository-instance.ts`）。
@@ -87,6 +98,9 @@ pnpm test:e2e:install   # Playwright（Chromium）を取得
 - `pnpm prisma:validate`: `.env.local` を読み込んでPrismaスキーマ検証
 - `pnpm prisma:pull`: `.env.local` を読み込んでSupabase定義をpull
 - `pnpm prisma:generate`: `.env.local` を読み込んでPrisma Client生成
+- `pnpm test`: Vitest UT（単体・jsdom・外部 I/O モック）
+- `pnpm test:it`: Vitest IT（結合・node・DB コンテナを起動して実 Postgres で実行）
+- `pnpm test:it:down`: IT 用テスト DB コンテナの破棄
 - `pnpm test:e2e`: Playwright E2E実行
 - `pnpm test:e2e:ui`: Playwright UIモード
 - `pnpm test:e2e:headed`: Headed実行

--- a/front/docker-compose.test.yml
+++ b/front/docker-compose.test.yml
@@ -1,0 +1,21 @@
+# IT / E2E(supabase レーン) 専用の使い捨て Postgres。
+# 共有 Supabase プロジェクトには一切接続しない（.claude/rules/testing.md・database.md）。
+# ホスト側は 5433 に公開し、共有 DB の 5432 と衝突しないようにする。
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: book-record-test-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: book_record_test
+    ports:
+      - "5433:5432"
+    # データを永続化しない（使い捨て・毎回クリーン）。
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d book_record_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:it": "docker compose -f docker-compose.test.yml up -d --wait && vitest run --config vitest.it.config.ts",
+    "test:it:down": "docker compose -f docker-compose.test.yml down -v",
     "prisma:generate": "node scripts/prisma-with-env-local.mjs generate",
     "prisma:pull": "node scripts/prisma-with-env-local.mjs db pull",
     "prisma:validate": "node scripts/prisma-with-env-local.mjs validate",

--- a/front/src/app/api/book-record/books/[id]/__tests__/route.it.test.ts
+++ b/front/src/app/api/book-record/books/[id]/__tests__/route.it.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/auth-guard", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/server/auth-guard")>();
+  return { ...actual, requireAuthenticatedUser: vi.fn(async () => {}) };
+});
+
+import { AuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
+import { disconnectDb, resetBookRecordTables } from "@/test/it-db";
+import { ctx, jsonReq, validBookBody } from "@/test/it-harness";
+import { POST as createBookRoute } from "../../route";
+import { GET, PATCH } from "../route";
+
+const authMock = vi.mocked(requireAuthenticatedUser);
+const MISSING_ID = "00000000-0000-0000-0000-000000000000";
+
+const seedBook = async (overrides: Partial<typeof validBookBody> = {}): Promise<string> => {
+  const res = await createBookRoute(jsonReq({ ...validBookBody, ...overrides }));
+  const { book } = await res.json();
+  return book.id as string;
+};
+
+beforeEach(async () => {
+  authMock.mockReset();
+  authMock.mockResolvedValue(undefined);
+  await resetBookRecordTables();
+});
+
+afterAll(async () => {
+  await disconnectDb();
+});
+
+describe("IT: /api/book-record/books/[id]（実 Postgres）", () => {
+  // 正常系
+  it("GET は該当書籍を返す", async () => {
+    const id = await seedBook();
+    const res = await GET(jsonReq({}), ctx(id));
+    expect(res.status).toBe(200);
+    const { book } = await res.json();
+    expect(book).toMatchObject({ id, title: validBookBody.title });
+  });
+
+  it("PATCH でフィールドを更新でき実 DB に反映される", async () => {
+    const id = await seedBook();
+    const res = await PATCH(jsonReq({ title: "改題後タイトル", tags: ["updated"] }), ctx(id));
+    expect(res.status).toBe(200);
+
+    const { book } = await (await GET(jsonReq({}), ctx(id))).json();
+    expect(book.title).toBe("改題後タイトル");
+    expect(book.tags).toEqual(["updated"]);
+  });
+
+  it("currentPage が総ページ以上なら completed へ自動遷移し completedAt が付与される", async () => {
+    const id = await seedBook({ totalPages: 300, status: "reading" });
+    const res = await PATCH(jsonReq({ currentPage: 300 }), ctx(id));
+    expect(res.status).toBe(200);
+
+    const { book } = await res.json();
+    expect(book.status).toBe("completed");
+    expect(book.completedAt).toEqual(expect.any(String));
+  });
+
+  // 準正常系 / 異常系
+  it("存在しない ID の GET は 404", async () => {
+    const res = await GET(jsonReq({}), ctx(MISSING_ID));
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ message: "対象の書籍が見つかりません。" });
+  });
+
+  it("存在しない ID の PATCH は 404", async () => {
+    const res = await PATCH(jsonReq({ title: "x" }), ctx(MISSING_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("未認証の PATCH は 401 で DB を変更しない", async () => {
+    const id = await seedBook({ title: "元タイトル" });
+    authMock.mockRejectedValueOnce(new AuthGuardError("ログインが必要です。", 401));
+
+    const res = await PATCH(jsonReq({ title: "侵入" }), ctx(id));
+    expect(res.status).toBe(401);
+
+    const { book } = await (await GET(jsonReq({}), ctx(id))).json();
+    expect(book.title).toBe("元タイトル");
+  });
+});

--- a/front/src/app/api/book-record/books/[id]/progress-logs/__tests__/route.it.test.ts
+++ b/front/src/app/api/book-record/books/[id]/progress-logs/__tests__/route.it.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/auth-guard", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/server/auth-guard")>();
+  return { ...actual, requireAuthenticatedUser: vi.fn(async () => {}) };
+});
+
+import { AuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
+import { disconnectDb, resetBookRecordTables } from "@/test/it-db";
+import { ctx, jsonReq, validBookBody } from "@/test/it-harness";
+import { POST as createBookRoute } from "../../../route";
+import { GET as getBook } from "../../route";
+import { GET, POST } from "../route";
+
+const authMock = vi.mocked(requireAuthenticatedUser);
+const MISSING_ID = "00000000-0000-0000-0000-000000000000";
+
+const seedBook = async (overrides: Partial<typeof validBookBody> = {}): Promise<string> => {
+  const res = await createBookRoute(jsonReq({ ...validBookBody, totalPages: 1000, ...overrides }));
+  const { book } = await res.json();
+  return book.id as string;
+};
+
+beforeEach(async () => {
+  authMock.mockReset();
+  authMock.mockResolvedValue(undefined);
+  await resetBookRecordTables();
+});
+
+afterAll(async () => {
+  await disconnectDb();
+});
+
+describe("IT: /api/book-record/books/[id]/progress-logs（実 Postgres・$transaction）", () => {
+  // 正常系: $transaction が book 更新と log 追加を原子的に確定する
+  it("進捗登録で book.currentPage 更新と log 追加が両方コミットされる", async () => {
+    const id = await seedBook();
+
+    const res = await POST(jsonReq({ page: 150, memo: "第3章まで", status: "reading" }), ctx(id));
+    expect(res.status).toBe(201);
+
+    const { book } = await (await getBook(jsonReq({}), ctx(id))).json();
+    expect(book.currentPage).toBe(150);
+
+    const { logs } = await (await GET(jsonReq({}), ctx(id))).json();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({ page: 150, memo: "第3章まで", status: "reading" });
+  });
+
+  it("到達ページが総ページ以上なら completed へ自動遷移する", async () => {
+    const id = await seedBook({ totalPages: 200 });
+    const res = await POST(jsonReq({ page: 200, memo: "", status: "reading" }), ctx(id));
+    expect(res.status).toBe(201);
+
+    const { book } = await (await getBook(jsonReq({}), ctx(id))).json();
+    expect(book.status).toBe("completed");
+    expect(book.completedAt).toEqual(expect.any(String));
+  });
+
+  it("進捗履歴は loggedAt 降順で返る", async () => {
+    const id = await seedBook();
+    await POST(jsonReq({ page: 10, memo: "", status: "reading", loggedAt: "2024-01-01T00:00:00.000Z" }), ctx(id)); // prettier-ignore
+    await POST(jsonReq({ page: 30, memo: "", status: "reading", loggedAt: "2024-01-03T00:00:00.000Z" }), ctx(id)); // prettier-ignore
+    await POST(jsonReq({ page: 20, memo: "", status: "reading", loggedAt: "2024-01-02T00:00:00.000Z" }), ctx(id)); // prettier-ignore
+
+    const { logs } = await (await GET(jsonReq({}), ctx(id))).json();
+    expect(logs.map((l: { page: number }) => l.page)).toEqual([30, 20, 10]);
+  });
+
+  // 準正常系 / 異常系: 失敗時に部分書き込みが残らない（原子性の裏面）
+  it("存在しない book への進捗登録は 404 で log を作らない", async () => {
+    const res = await POST(jsonReq({ page: 10, memo: "", status: "reading" }), ctx(MISSING_ID));
+    expect(res.status).toBe(404);
+
+    const { logs } = await (await GET(jsonReq({}), ctx(MISSING_ID))).json();
+    expect(logs).toEqual([]);
+  });
+
+  it("完読条件未達で completed 指定 → 400・log 無し・currentPage 不変", async () => {
+    const id = await seedBook({ totalPages: 1000 });
+
+    const res = await POST(jsonReq({ page: 50, memo: "", status: "completed" }), ctx(id));
+    expect(res.status).toBe(400);
+
+    const { book } = await (await getBook(jsonReq({}), ctx(id))).json();
+    expect(book.currentPage).toBe(0);
+    const { logs } = await (await GET(jsonReq({}), ctx(id))).json();
+    expect(logs).toEqual([]);
+  });
+
+  it("未認証の進捗登録は 401", async () => {
+    const id = await seedBook();
+    authMock.mockRejectedValueOnce(new AuthGuardError("ログインが必要です。", 401));
+
+    const res = await POST(jsonReq({ page: 10, memo: "", status: "reading" }), ctx(id));
+    expect(res.status).toBe(401);
+
+    const { logs } = await (await GET(jsonReq({}), ctx(id))).json();
+    expect(logs).toEqual([]);
+  });
+});

--- a/front/src/app/api/book-record/books/[id]/reflection/__tests__/route.it.test.ts
+++ b/front/src/app/api/book-record/books/[id]/reflection/__tests__/route.it.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/auth-guard", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/server/auth-guard")>();
+  return { ...actual, requireAuthenticatedUser: vi.fn(async () => {}) };
+});
+
+import { AuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
+import { disconnectDb, resetBookRecordTables } from "@/test/it-db";
+import { ctx, jsonReq, validBookBody } from "@/test/it-harness";
+import { POST as createBookRoute } from "../../../route";
+import { POST } from "../route";
+
+const authMock = vi.mocked(requireAuthenticatedUser);
+const MISSING_ID = "00000000-0000-0000-0000-000000000000";
+
+const seedBook = async (): Promise<string> => {
+  const res = await createBookRoute(jsonReq(validBookBody));
+  const { book } = await res.json();
+  return book.id as string;
+};
+
+beforeEach(async () => {
+  authMock.mockReset();
+  authMock.mockResolvedValue(undefined);
+  await resetBookRecordTables();
+});
+
+afterAll(async () => {
+  await disconnectDb();
+});
+
+describe("IT: /api/book-record/books/[id]/reflection（実 Postgres・upsert）", () => {
+  // 正常系
+  it("感想を初回保存すると book に反映される", async () => {
+    const id = await seedBook();
+    const res = await POST(
+      jsonReq({ learning: "学び", action: "次の行動", quote: "引用" }),
+      ctx(id)
+    );
+    expect(res.status).toBe(200);
+
+    const { book } = await res.json();
+    expect(book.reflection).toMatchObject({ learning: "学び", action: "次の行動", quote: "引用" });
+  });
+
+  it("再保存は upsert で内容を上書きしつつ createdAt を維持する", async () => {
+    const id = await seedBook();
+    const first = await (
+      await POST(jsonReq({ learning: "初版", action: "a1", quote: "q1" }), ctx(id))
+    ).json();
+    const createdAt = first.book.reflection.createdAt as string;
+    expect(createdAt).toEqual(expect.any(String));
+
+    const second = await (
+      await POST(jsonReq({ learning: "改訂版", action: "a2", quote: "q2" }), ctx(id))
+    ).json();
+
+    // 内容は上書き、作成日時は初回のまま（採番し直さない）。
+    expect(second.book.reflection).toMatchObject({ learning: "改訂版", action: "a2", quote: "q2" });
+    expect(second.book.reflection.createdAt).toBe(createdAt);
+  });
+
+  // 準正常系 / 異常系
+  it("存在しない book への感想保存は 404", async () => {
+    const res = await POST(jsonReq({ learning: "x", action: "y", quote: "z" }), ctx(MISSING_ID));
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ message: "対象の書籍が見つかりません。" });
+  });
+
+  it("パース不能なボディ（learning が欠落）は 400", async () => {
+    const id = await seedBook();
+    const res = await POST(jsonReq({ action: "y", quote: "z" }), ctx(id));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ message: "感想保存リクエストが不正です。" });
+  });
+
+  it("未認証の感想保存は 401", async () => {
+    const id = await seedBook();
+    authMock.mockRejectedValueOnce(new AuthGuardError("ログインが必要です。", 401));
+
+    const res = await POST(jsonReq({ learning: "x", action: "y", quote: "z" }), ctx(id));
+    expect(res.status).toBe(401);
+  });
+});

--- a/front/src/app/api/book-record/books/[id]/reflection/__tests__/route.test.ts
+++ b/front/src/app/api/book-record/books/[id]/reflection/__tests__/route.test.ts
@@ -97,7 +97,9 @@ describe("POST /api/book-record/books/[id]/reflection（認証必須）", () => 
   });
 
   it("リポジトリが未検出エラーを投げれば 404 に写像する", async () => {
-    H.saveReflection.mockRejectedValue(new H.RepositoryNotFoundError("対象の書籍が見つかりません。"));
+    H.saveReflection.mockRejectedValue(
+      new H.RepositoryNotFoundError("対象の書籍が見つかりません。")
+    );
     const res = await POST(jsonReq(validBody), ctx("missing"));
     expect(res.status).toBe(404);
   });

--- a/front/src/app/api/book-record/books/__tests__/route.it.test.ts
+++ b/front/src/app/api/book-record/books/__tests__/route.it.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// 認証境界（Supabase Auth = ネットワーク I/O）のみモックし、Prisma は実 Postgres を使う。
+// AuthGuardError / isAuthGuardError は本物を残し、ルートの 401 写像を実挙動のまま検証する。
+vi.mock("@/lib/server/auth-guard", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/server/auth-guard")>();
+  return { ...actual, requireAuthenticatedUser: vi.fn(async () => {}) };
+});
+
+import { AuthGuardError, requireAuthenticatedUser } from "@/lib/server/auth-guard";
+import { disconnectDb, resetBookRecordTables } from "@/test/it-db";
+import { jsonReq, validBookBody } from "@/test/it-harness";
+import { GET, POST } from "../route";
+
+const authMock = vi.mocked(requireAuthenticatedUser);
+
+/**
+ * POST /books を叩いて作成書籍 ID を返す（正常系ヘルパ）。
+ *
+ * @param overrides - validBookBody を部分的に上書きするフィールド
+ * @returns 作成された書籍の ID
+ */
+const createBook = async (overrides: Partial<typeof validBookBody> = {}): Promise<string> => {
+  const res = await POST(jsonReq({ ...validBookBody, ...overrides }));
+  expect(res.status).toBe(201);
+  const { book } = await res.json();
+  return book.id as string;
+};
+
+beforeEach(async () => {
+  authMock.mockReset();
+  authMock.mockResolvedValue(undefined);
+  await resetBookRecordTables();
+});
+
+afterAll(async () => {
+  await disconnectDb();
+});
+
+describe("IT: /api/book-record/books（実 Postgres）", () => {
+  // 正常系
+  it("初期状態の GET は空配列を返す", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const { books } = await res.json();
+    expect(books).toEqual([]);
+  });
+
+  it("POST で作成した書籍が実 DB に永続化され GET で取得できる", async () => {
+    const id = await createBook();
+
+    const res = await GET();
+    const { books } = await res.json();
+    expect(books).toHaveLength(1);
+    expect(books[0]).toMatchObject({
+      id,
+      title: validBookBody.title,
+      author: validBookBody.author,
+      totalPages: 300,
+      currentPage: 0,
+      status: "reading",
+      tags: ["tdd", "test"],
+    });
+  });
+
+  it("一覧は updatedAt 降順で並ぶ（更新した書籍が先頭に来る）", async () => {
+    await createBook({ title: "A" });
+    await createBook({ title: "B" });
+    const idC = await createBook({ title: "C" });
+
+    // A を更新して updatedAt を最新化 → 先頭へ来ることで第一ソートキーを実 DB の ORDER BY で検証。
+    const first = (await (await GET()).json()).books.find(
+      (b: { title: string }) => b.title === "A"
+    );
+    await (
+      await import("../[id]/route")
+    ).PATCH(jsonReq({ author: "改訂" }), {
+      params: Promise.resolve({ id: first.id }),
+    });
+
+    const { books } = await (await GET()).json();
+    expect(books.map((b: { title: string }) => b.title)).toEqual(["A", "C", "B"]);
+    expect(books[0].id).not.toBe(idC);
+  });
+
+  // 準正常系 / 異常系
+  it("未認証の POST は 401 を返し DB を変更しない", async () => {
+    authMock.mockRejectedValueOnce(new AuthGuardError("ログインが必要です。", 401));
+
+    const res = await POST(jsonReq(validBookBody));
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ message: "ログインが必要です。" });
+
+    const { books } = await (await GET()).json();
+    expect(books).toEqual([]);
+  });
+
+  it("パース不能なボディ（totalPages が文字列）は 400", async () => {
+    const res = await POST(jsonReq({ ...validBookBody, totalPages: "300" }));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ message: "書籍作成リクエストが不正です。" });
+  });
+
+  it("リポジトリ検証違反（totalPages=0）は 400 で DB に残らない", async () => {
+    const res = await POST(jsonReq({ ...validBookBody, totalPages: 0 }));
+    expect(res.status).toBe(400);
+    const { books } = await (await GET()).json();
+    expect(books).toEqual([]);
+  });
+});

--- a/front/src/test/it-db.ts
+++ b/front/src/test/it-db.ts
@@ -1,0 +1,23 @@
+import { prisma } from "@/lib/server/prisma-client";
+
+/**
+ * IT 各ケース間で BookRecord 系テーブルを初期化する。
+ * DB 状態を共有する直列実行前提のため、各 `beforeEach` で呼び出して独立性を担保する。
+ * TRUNCATE ... CASCADE で進捗ログ・感想も併せて消す（外部キーで連鎖）。
+ *
+ * @returns 初期化完了の Promise
+ */
+export const resetBookRecordTables = async (): Promise<void> => {
+  await prisma.$executeRawUnsafe(
+    'TRUNCATE TABLE "BookRecordProgressLogs", "BookRecordReflections", "BookRecordBooks" RESTART IDENTITY CASCADE'
+  );
+};
+
+/**
+ * IT スイート終了時に Prisma 接続を破棄する。開いたままだとワーカーが終了しない。
+ *
+ * @returns 切断完了の Promise
+ */
+export const disconnectDb = async (): Promise<void> => {
+  await prisma.$disconnect();
+};

--- a/front/src/test/it-global-setup.ts
+++ b/front/src/test/it-global-setup.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * IT 実行前に一度だけ走るグローバルセットアップ。
+ * テストコンテナの Postgres へ `prisma db push` でスキーマを投入する。
+ *
+ * 破壊防止のため、DATABASE_URL がローカルの使い捨てコンテナ以外を指す場合は中断する
+ * （共有 Supabase への push/migrate は禁止。`.claude/rules/database.md` の例外規定に対応）。
+ */
+
+// DATABASE_URL がテストコンテナ（localhost:5433）を指すことを厳格に検証する安全弁。
+const assertDisposableTestDatabase = (rawUrl: string | undefined): void => {
+  if (!rawUrl) {
+    throw new Error("IT: DATABASE_URL が未設定です。.env.test を確認してください。");
+  }
+
+  const url = new URL(rawUrl);
+  const isLocalHost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  const isTestPort = url.port === "5433";
+  // 共有 Supabase を誤って壊さないための多重ガード。
+  const looksRemote = /supabase\.(co|com)|amazonaws\.com/i.test(url.hostname);
+
+  if (!isLocalHost || !isTestPort || looksRemote) {
+    throw new Error(
+      `IT: DATABASE_URL がテストコンテナ(localhost:5433)を指していません: ${url.hostname}:${url.port}. ` +
+        "共有 DB への db push を防ぐため中断します。"
+    );
+  }
+};
+
+/**
+ * Vitest グローバルセットアップのエントリポイント。
+ *
+ * @throws {Error} DATABASE_URL が使い捨てコンテナ以外を指す場合、または db push 失敗時
+ */
+export default function setup(): void {
+  assertDisposableTestDatabase(process.env.DATABASE_URL);
+
+  // テストコンテナへスキーマを materialize する。--skip-generate は Client 生成を分離済みのため。
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "prisma", "db", "push", "--skip-generate", "--accept-data-loss"],
+    {
+      stdio: "inherit",
+      env: process.env,
+    }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      "IT: prisma db push に失敗しました。テストコンテナが起動しているか確認してください。"
+    );
+  }
+}

--- a/front/src/test/it-harness.ts
+++ b/front/src/test/it-harness.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from "next/server";
+
+/**
+ * IT 用の最小リクエストダブル。Route Handler は `request.json()` しか参照せず、
+ * 認証は `auth-guard` をモックして差し替えるため、ヘッダ等は不要。
+ *
+ * @param body - `request.json()` が返す任意の JSON 値
+ * @returns NextRequest として扱える最小オブジェクト
+ */
+export const jsonReq = (body: unknown): NextRequest =>
+  ({ json: async () => body }) as unknown as NextRequest;
+
+/**
+ * 動的ルートの `context`（`params` は Promise）を組み立てる。
+ *
+ * @param id - ルートパラメータの書籍 ID
+ * @returns Route Handler へ渡す context
+ */
+export const ctx = (id: string): { params: Promise<{ id: string }> } => ({
+  params: Promise.resolve({ id }),
+});
+
+/** 妥当な書籍作成ボディ。個別テストで一部を壊して準正常系を作る。 */
+export const validBookBody = {
+  title: "実践テスト駆動開発",
+  author: "テスト太郎",
+  genre: "技術書",
+  format: "paper" as const,
+  totalPages: 300,
+  tags: ["tdd", "test"],
+  status: "reading" as const,
+};

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { defineConfig } from "vitest/config";
 
 // UT（単体）専用構成。外部 I/O をモックし DB・ネットワーク非依存で実行する。
-// IT（*.it.test.ts）は DB 依存のため別構成（PR-C で vitest.it.config.ts を追加）で分離する。
+// IT（*.it.test.ts）は DB 依存のため別構成（vitest.it.config.ts）で分離する。
 export default defineConfig({
   test: {
     environment: "jsdom",

--- a/front/vitest.it.config.ts
+++ b/front/vitest.it.config.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+// docker-compose.test.yml の使い捨てコンテナに対応する既定接続先。
+// .env.test を置かなくても IT が回るよう、コミット不要な安全なローカル値をフォールバックにする。
+const DEFAULT_IT_ENV: Record<string, string> = {
+  DATABASE_URL: "postgresql://postgres:postgres@localhost:5433/book_record_test?schema=public",
+  DIRECT_URL: "postgresql://postgres:postgres@localhost:5433/book_record_test?schema=public",
+};
+
+/**
+ * IT（結合）専用構成。UT（`vitest.config.ts`）とは分離する。
+ * - Prisma はモックせず、`docker-compose.test.yml` の使い捨て Postgres に対して実行する。
+ * - スキーマは `globalSetup` で `prisma db push`（テストコンテナ限定の例外運用）で投入する。
+ * - DB 状態を共有するため直列実行（`fileParallelism: false` / 単一フォーク）にする。
+ */
+
+// .env.test を最小パースして process.env へ流し込む。
+// prisma-client.ts は import 時に DATABASE_URL を読むため、ワーカーにも env を渡す必要がある。
+const loadTestEnv = (): Record<string, string> => {
+  const file = path.resolve(__dirname, ".env.test");
+  // .env.test はローカル上書き用（gitignore）。無ければコンテナ既定値で動かす。
+  if (!existsSync(file)) {
+    return { ...DEFAULT_IT_ENV };
+  }
+  const env: Record<string, string> = { ...DEFAULT_IT_ENV };
+  for (const raw of readFileSync(file, "utf8").split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+};
+
+const testEnv = loadTestEnv();
+// globalSetup と `prisma db push` の子プロセスも同じ DATABASE_URL を見る必要があるため main 側にも反映する。
+Object.assign(process.env, testEnv);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.it.test.ts"],
+    exclude: ["node_modules", "e2e/**"],
+    globalSetup: ["src/test/it-global-setup.ts"],
+    // DB 状態を共有するため直列で回す（並行だと truncate と読み書きが競合する）。
+    // Vitest 4 では poolOptions が廃止されトップレベル指定になった。
+    fileParallelism: false,
+    maxWorkers: 1,
+    // 実 DB アクセス・スキーマ投入を待つため UT より長めに取る。
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    // ワーカープロセスへ DATABASE_URL 等を伝搬する。
+    env: testEnv,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      // サーバー専用ガード（import "server-only"）はテスト実行環境では不要なため空スタブへ差し替える。
+      "server-only": path.resolve(__dirname, "./src/test/server-only-stub.ts"),
+    },
+  },
+});


### PR DESCRIPTION
## 概要

テストの地盤強化として **IT（結合テスト）基盤** を新規導入し、**CI を「E2E のみ」→「静的ゲート＋UT＋IT＋E2E」の4ジョブ**へ拡張しました。

IT は `docs/08` の定義どおり **Route Handler + `PrismaBookRecordRepository` → 実 Postgres** を対象とし、認証境界（Supabase Auth）のみモックして Prisma は使い捨てコンテナで検証します。UT では原理的に検証できない挙動を担保します。

## IT が担保する「UT では不可能」な挙動（23ケース・正常1:異常2以上）

- **`$transaction` 原子性** — 進捗登録で book 更新 + log 追加が両方コミット／失敗時（404・完読未達400）は**部分書き込みゼロ**（`currentPage` 不変・log 0件）
- **reflection upsert 上書き**で `createdAt` を維持
- 実 DB の **ORDER BY**（`updatedAt` 降順・`loggedAt` 降順）
- 完読 **自動遷移** + `completedAt` 付与、401/404/400 の実写像

## 構成物

| ファイル | 役割 |
|---|---|
| `front/docker-compose.test.yml` | 使い捨て postgres:16（`localhost:5433`・**共有 Supabase 非接続**） |
| `front/vitest.it.config.ts` | IT 専用構成（node・直列・globalSetup・`.env.test` フォールバック） |
| `front/src/test/it-global-setup.ts` | `prisma db push`。**DATABASE_URL が localhost:5433 以外なら中断する安全弁** |
| `front/src/test/it-db.ts` / `it-harness.ts` | truncate ヘルパ・リクエストダブル |
| `.../__tests__/*.it.test.ts` ×4 | 4 Route グループの IT 本体 |

`package.json` に `test:it` / `test:it:down` を追加。

## CI（`.github/workflows/ci.yml`）

`E2E Tests` → **`CI`**（4ジョブ並列）:
- **`static`**: `format:check` / `lint` / `tsc --noEmit` ← ゲート追加で顕在化した既存 format 崩れ（`reflection/route.test.ts`・main 由来）も本 PR で解消
- **`ut`**: `pnpm test`（112）
- **`it`**: `pnpm test:it`（23・docker compose で実 Postgres）
- **`e2e`**: 既存 Playwright（local・Case 1-18）

## 検証（ローカルで CI 全ジョブ相当を green 確認）

- static: format:check ✅ / lint ✅ / tsc ✅
- UT ✅ 112 / IT ✅ 23

## ドキュメント同期（documentation ルール）

- `docs/09` §6: CI 4ジョブ構成を追記
- `README`（root/front）: バッジ名 `E2E Tests`→`CI`・UT/IT コマンド・IT の DB コンテナ運用
- `front/vitest.config.ts`: stale コメント修正

## スコープ外

- **E2E supabase レーン**は未対応（別 PR で対応予定）。本 PR は IT 基盤＋CI 配線に集中。
- `.env.test` は gitignore のまま（接続先の既定値は `vitest.it.config.ts` にフォールバックとして保持。シークレット非コミット方針を厳守）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)