### PR TITLE
chore: リポジトリルートに Makefile を追加（pnpm scripts の入口を一本化）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,121 @@
+# Book Reading Record Web App — タスクランナー
+#
+# 実体は front/package.json の pnpm scripts。本 Makefile はその薄いラッパーで、
+# リポジトリルートのどこからでも同じ入口で叩けるようにする（二重管理を避ける）。
+# 使い方: `make help` で一覧表示。
+
+# 実装本体のディレクトリ（全 pnpm ターゲットはここで実行する）
+FRONT := front
+# IT / E2E(supabase レーン) 用の使い捨て Postgres（共有 Supabase には接続しない）
+COMPOSE_FILE := $(FRONT)/docker-compose.test.yml
+DB_SERVICE := db
+
+# 引数なし `make` は help を表示する（誤って dev 等を起動しない安全側）
+.DEFAULT_GOAL := help
+
+.PHONY: help \
+	install e2e-install \
+	dev build start \
+	lint lint-fix format format-check check \
+	test test-watch test-it test-e2e test-e2e-ui test-e2e-headed test-all \
+	prisma-generate prisma-pull prisma-validate \
+	db-up db-down db-logs db-psql \
+	screenshots clean
+
+## ---- Setup ----------------------------------------------------------------
+
+install: ## 依存パッケージをインストール（pnpm install）
+	cd $(FRONT) && pnpm install
+
+e2e-install: ## Playwright 用 Chromium をインストール
+	cd $(FRONT) && pnpm test:e2e:install
+
+## ---- Develop --------------------------------------------------------------
+
+dev: ## 開発サーバーを起動（next dev）
+	cd $(FRONT) && pnpm dev
+
+build: ## 本番ビルド（内部で prisma generate を実行）
+	cd $(FRONT) && pnpm build
+
+start: ## ビルド済みアプリを起動（next start）
+	cd $(FRONT) && pnpm start
+
+## ---- Quality (static gate) ------------------------------------------------
+
+lint: ## ESLint を実行
+	cd $(FRONT) && pnpm lint
+
+lint-fix: ## ESLint を自動修正付きで実行
+	cd $(FRONT) && pnpm lint:fix
+
+format: ## Prettier で整形（書き込み）
+	cd $(FRONT) && pnpm format
+
+format-check: ## Prettier の整形チェック（CI 相当）
+	cd $(FRONT) && pnpm format:check
+
+check: format-check lint ## 静的ゲート一括（format:check → lint）
+
+## ---- Test (3層: UT / IT / E2E) --------------------------------------------
+
+test: ## UT（Vitest / jsdom・DB 不要）
+	cd $(FRONT) && pnpm test
+
+test-watch: ## UT を watch モードで実行
+	cd $(FRONT) && pnpm test:watch
+
+test-it: ## IT（Vitest / node・DB コンテナで実 Postgres・要 Docker）
+	cd $(FRONT) && pnpm test:it
+
+test-e2e: ## E2E（Playwright / Chromium・local レーン）
+	cd $(FRONT) && pnpm test:e2e
+
+test-e2e-ui: ## E2E を UI モードで起動
+	cd $(FRONT) && pnpm test:e2e:ui
+
+test-e2e-headed: ## E2E をヘッド付きで起動
+	cd $(FRONT) && pnpm test:e2e:headed
+
+test-all: test test-it test-e2e ## UT → IT → E2E を順に実行
+
+## ---- Prisma ---------------------------------------------------------------
+
+prisma-generate: ## Prisma Client を生成
+	cd $(FRONT) && pnpm prisma:generate
+
+prisma-pull: ## 既存 Supabase から schema を db pull（共有 DB へ push しない）
+	cd $(FRONT) && pnpm prisma:pull
+
+prisma-validate: ## schema.prisma を検証
+	cd $(FRONT) && pnpm prisma:validate
+
+## ---- Test DB container (使い捨て Postgres) ---------------------------------
+
+db-up: ## テスト用 Postgres を起動（healthy まで待機）
+	docker compose -f $(COMPOSE_FILE) up -d --wait
+
+db-down: ## テスト用 Postgres を停止しボリューム破棄
+	cd $(FRONT) && pnpm test:it:down
+
+db-logs: ## テスト用 Postgres のログを追従表示
+	docker compose -f $(COMPOSE_FILE) logs -f $(DB_SERVICE)
+
+db-psql: ## テスト用 Postgres に psql 接続
+	docker compose -f $(COMPOSE_FILE) exec $(DB_SERVICE) psql -U postgres -d book_record_test
+
+## ---- Misc -----------------------------------------------------------------
+
+screenshots: ## docs/assets 用スクリーンショットを再生成
+	cd $(FRONT) && pnpm screenshots
+
+clean: ## ビルド生成物とテスト用 DB コンテナを掃除
+	cd $(FRONT) && rm -rf .next test-results
+	-docker compose -f $(COMPOSE_FILE) down -v
+
+help: ## このヘルプを表示
+	@echo "Book Reading Record Web App — make targets"
+	@echo ""
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ pnpm test:it        # Vitest IT（結合・DB コンテナで実 Postgres・要 
 pnpm test:e2e       # Playwright E2E（local モードで起動）
 ```
 
+### Make（ルートからの一本化入口）
+
+上記 pnpm scripts はルートの `Makefile` からも叩けます。実体は同じ pnpm scripts の薄いラッパーで、`front/` に `cd` せずリポジトリルートから実行できます。
+
+```bash
+make help           # 全ターゲット一覧（説明付き）
+make install        # 依存インストール（pnpm install）
+make dev            # 開発サーバー起動（next dev）
+make check          # 静的ゲート一括（format:check → lint）
+make test           # UT / make test-it: IT / make test-e2e: E2E
+make test-all       # UT → IT → E2E を順に実行
+make db-up / db-down  # IT 用 Postgres コンテナの起動 / 破棄
+```
+
 > `pnpm build` / `pnpm test:e2e:install` の詳細・IT の DB コンテナ運用・E2E のUIモード等は [front/README.md](front/README.md) を参照。
 > 開発フロー（ブランチ運用・テスト必須・PR ルール）は [.claude/rules/](.claude/rules/) にまとまっています。
 


### PR DESCRIPTION
## 概要

`front/package.json` の pnpm scripts を薄くラップする `Makefile` をリポジトリルートに追加します。`front/` に `cd` せず、ルートから `make <target>` で同じ操作を叩けるようにするのが目的です。

## 背景

- リポジトリに Makefile が存在しなかった（ルート・`front/` とも）。
- コマンドの実体は pnpm scripts に集約されているため、Makefile は**その薄いラッパー**として二重管理を避ける方針で作成。

## 変更内容

- **`Makefile`（新規）**: 7グループ26ターゲット
  - Setup: `install` / `e2e-install`
  - Develop: `dev` / `build` / `start`
  - Quality: `lint` / `lint-fix` / `format` / `format-check` / `check`(一括)
  - Test(3層): `test`(UT) / `test-it`(IT) / `test-e2e` ほか / `test-all`
  - Prisma: `prisma-generate` / `prisma-pull` / `prisma-validate`
  - Test DB: `db-up` / `db-down` / `db-logs` / `db-psql`
  - Misc: `screenshots` / `clean` / `help`
  - `.DEFAULT_GOAL := help`（引数なし `make` は誤起動せずヘルプ表示）
  - 各ターゲット末尾の `## コメント` から自動生成する self-documenting な `make help`
- **`README.md`**: Development セクションに「Make（ルートからの一本化入口）」小節を追記

## 設計メモ

- 各レシピは `cd front && pnpm ...`。`cd` はレシピ行ごとにスコープされるため他ターゲットへ漏れない。
- `db-down` は既存 `pnpm test:it:down` に委譲し、コンテナ停止手順の唯一の真実を package.json 側に保持。
- 実行手段そのものは不変（pnpm scripts の代替入口を足しただけ）。既存の pnpm ワークフローは併記で維持。

## ドキュメント同期

- 影響マップ「ビルド・実行・設定の変更 → README.md」に対応し、ルート `README.md` を更新済み。
- `CLAUDE.md` / `front/README.md` は変更不要（実行手段は不変・詳細な pnpm 運用は front 側に既存でルートから相互参照済み）。

## 動作確認

- `make help` → 全ターゲットを説明付きで表示 ✅
- `make -n test` → `cd front && pnpm test` に展開 ✅
- `make -n check` → `format:check` → `lint` の2段に展開 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)