### PR TITLE
chore(rules): GitHub issue 運用ルール（github-issue.md）を追加

### DIFF
--- a/.claude/rules/github-issue.md
+++ b/.claude/rules/github-issue.md
@@ -1,0 +1,20 @@
+---
+description: GitHub issue 運用（ブランチと対で issue を作成し open/close で進捗管理）
+globs: 
+---
+
+# GitHub issue 運用
+
+開発の作業単位を GitHub issue で管理する。
+
+- **issue 起票**: 開発を開始する際、作業ブランチを切るのと対で、対応する GitHub issue を作成する（作業単位 = 1 issue）。
+- **進捗管理**: issue の状態で進捗を表す。
+  - **対応中**: issue は open のままにする。
+  - **完了**: 対応する PR のマージで issue をクローズする（下記の自動クローズを使う）。
+- **ブランチとの紐付け**: ブランチ名は GitHub Flow の命名規約（feat/*, fix/*, chore/* 等）に従い、対応する issue を PR で参照する。
+- **PR での自動クローズ**: PR 本文に `Closes #<issue番号>`（バグ修正は `Fixes #<issue番号>`）を記載し、マージ時に issue を自動クローズする。
+- **粒度**: 1 issue = 1 PR で閉じられるまとまった作業を基本とする。
+- **サブ issue（作業を分割する場合）**: 作業が大きく大枠・中枠・小枠に分かれる場合は、大枠を親 issue、中枠・小枠をサブ issue として起票する。
+  - 親 issue に、サブ issue へのリンクをチェックリスト（`- [ ] #<番号>`）で列挙し、進捗を集約する（GitHub のサブ issue 機能を使ってもよい）。
+  - 各サブ issue も通常どおりブランチ・PR と対応させ、PR の `Closes #<サブissue番号>` でクローズする。全サブ issue が閉じたら親 issue を閉じる。
+  - 分割が不要な小さい作業は単一 issue でよい（無理に親子化しない）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 | quality-gate.md | 全体 | 品質ゲート（セルフレビュー・設計/実装レビュー） |
 | documentation.md | 全体 | ドキュメント更新ルール |
 | git.md | 全体 | GitHub Flow・ブランチ命名・push 禁止物 |
+| github-issue.md | 全体 | GitHub issue 運用（ブランチと対で起票・open/close で進捗管理・サブ issue） |
 | testing.md | 全体 | テスト分類・原則・3層(UT/IT/E2E)・モック/DBコンテナ方針 |
 | coding-standards.md | 全体 | コーディング規約（TypeScript strict・pnpm・ESLint/Prettier） |
 | error-handling.md | 全体 | エラーハンドリング方針（バリデーション・HTTP ステータス・統一レスポンス） |


### PR DESCRIPTION
## 概要

`/rules-update` スキルに新設された共通ルール `github-issue.md`（GitHub issue 駆動開発の運用）を、本リポジトリの `.claude/rules/` に取り込む。

## 変更点

- `.claude/rules/github-issue.md` を新規追加（ブランチと対で issue を起票 → open/close で進捗管理 → PR の `Closes #N` で自動クローズ → 親/サブ issue による作業分割）。skill テンプレートを frontmatter 込みでそのまま出力（スタック非依存の共通ルール）。
- `CLAUDE.md` の `## Rules` テーブルに `github-issue.md` 行を同期追加（`git.md` の直後）。

## ドキュメント乖離チェック（documentation.md 影響マップ）

- 変更種別「開発ルール / 規約の変更」→ 更新必須は `CLAUDE.md` / `.claude/rules/`。本 PR で両方更新済み。

## レビュー確認事項

- ブランチ命名の表記ゆれ: 取り込んだ `github-issue.md` は `feat/*` 表記だが、本リポジトリの `git.md` と実運用は `feature/*`。統一が必要なら別途対応（本 PR では skill テンプレートをそのまま取り込む方針）。

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)