### PR TITLE
fix(ci): 変更範囲の判定を paths-filter から明示的な照合に置き換える

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -85,12 +85,14 @@ jobs:
         run: |
           set -euo pipefail
           files=$(git diff --name-only "$(git merge-base "$BASE_SHA" HEAD)" HEAD)
+          emit() {
+            if [ -n "$2" ]; then echo "$1=true" >> "$GITHUB_OUTPUT"
+            else echo "$1=false" >> "$GITHUB_OUTPUT"; fi
+          }
           docs_re='(^|/)[^/]*\.md$|^docs/|^\.claude/'
           # code は docs の否定（＝除外リスト方式）で求める
-          [ -n "$(printf '%s\n' "$files" | grep -vE "$docs_re" || true)" ] \
-            && echo "code=true"  >> "$GITHUB_OUTPUT" || echo "code=false" >> "$GITHUB_OUTPUT"
-          [ -n "$(printf '%s\n' "$files" | grep -E  "$docs_re" || true)" ] \
-            && echo "docs=true"  >> "$GITHUB_OUTPUT" || echo "docs=false" >> "$GITHUB_OUTPUT"
+          emit code "$(printf '%s\n' "$files" | grep -vE "$docs_re" || true)"
+          emit docs "$(printf '%s\n' "$files" | grep -E  "$docs_re" || true)"
 
   test:                         # コード変更時のみ中身を実行（必須チェック）
     needs: changes
@@ -113,6 +115,7 @@ jobs:
 - **base commit を解決できない場合（初回 push・force push 等）は、全ファイルが変更されたものとして扱う**。判定不能を「変更なし」に倒すと、検査が黙って飛ぶ。
 - **変更ファイル一覧をログ（`$GITHUB_STEP_SUMMARY`）に出す**。何がスキップされたか追えないと、スキップは「検査して通った」と見分けがつかない。
 - **判定ロジックを変えたら、スキップ経路を実際に踏む PR で確認する**。全ジョブが「起動して成功」しても、それは**スキップが効いていないことの証明にはならない**。
+- **`run:` のスクリプトは actionlint 経由で shellcheck にかけられる**。指摘は抑制せず直す（変数の間接参照は避ける・同一ファイルへの連続リダイレクトは `{ ... } >> file` でまとめる）。ローカルでは該当スクリプトを切り出して `shellcheck` を通せる。
 - 必須チェックにしないワークフロー（デプロイ等）は、ワークフローレベルの `paths-ignore` を使ってよい（起動そのものを止める方が安価）。
 
 ## デプロイの発火

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -59,29 +59,38 @@ globs: ".github/workflows/**"
 - **ドキュメント変更 → markdown lint / リンク切れチェック**（テスト・ビルドは不要）
 - **両方を含む PR → 両方が走る**。片方の判定がもう片方を抑制してはならない。
 
+**判定は glob マッチャに任せず、変更ファイル一覧への明示的なパターン照合で行う。**
+
+`dorny/paths-filter` は**フィルタ内の複数パターンを OR で評価する**ため、「`docs/` でも `.claude/` でも `*.md` でもない」という **AND 条件を表現できない**。単一の extglob `!(docs/**|**/*.md|.claude/**)` は **`/` を跨げない**ため、`.claude/rules/api.md` や `README.md` が除外されず、ドキュメントだけの PR でもコードレーンが起動する（本リポジトリで実際に発生した）。
+
 ```yaml
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  changes:                      # 変更範囲を判定する（フィルタは用途ごとに独立させる）
+  changes:                      # 変更範囲を判定する（判定は用途ごとに独立させる）
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            code:
-              - '!(docs/**|**/*.md|.claude/**|LICENSE)'
-            docs:
-              - 'docs/**'
-              - '**/*.md'
-              - '.claude/**'
+          fetch-depth: 0        # merge-base の算出に全履歴が要る
+      - id: filter
+        env:
+          # ${{ }} を run: に直接埋め込まない（コマンドインジェクション対策）
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          files=$(git diff --name-only "$(git merge-base "$BASE_SHA" HEAD)" HEAD)
+          docs_re='(^|/)[^/]*\.md$|^docs/|^\.claude/'
+          # code は docs の否定（＝除外リスト方式）で求める
+          [ -n "$(printf '%s\n' "$files" | grep -vE "$docs_re" || true)" ] \
+            && echo "code=true"  >> "$GITHUB_OUTPUT" || echo "code=false" >> "$GITHUB_OUTPUT"
+          [ -n "$(printf '%s\n' "$files" | grep -E  "$docs_re" || true)" ] \
+            && echo "docs=true"  >> "$GITHUB_OUTPUT" || echo "docs=false" >> "$GITHUB_OUTPUT"
 
   test:                         # コード変更時のみ中身を実行（必須チェック）
     needs: changes
@@ -99,8 +108,11 @@ jobs:
 ```
 
 - **`code` と `docs` は排他ではない**。両方 `true` になる PR（実装 + ドキュメント更新）が正常系であり、`if/else` 的な二者択一で書かない。`.claude/rules/documentation.md` は「コード変更とドキュメント更新を同一 PR で行う」ことを完了条件としているため、**両方走る PR が最も多くなる**。
-- **`code` フィルタは「除外リスト」で書く**（`docs/**` 等以外はコード変更とみなす）。「対象リスト」で書くと、**新しいディレクトリが増えたときに黙ってテストが走らなくなる**。安全側に倒す。
-- 逆に **`docs` フィルタは「対象リスト」で書く**。ドキュメント検査は走りすぎても害が小さく、走らない方が問題になるため、判断の向きがコードとは逆になる。
+- **`code` は「除外リストの否定」で求める**（`docs/` 等以外はコード変更とみなす）。「対象リスト」で書くと、**新しいディレクトリが増えたときに黙ってテストが走らなくなる**。安全側に倒す。
+- 逆に **`docs` は「対象リスト」で書く**。ドキュメント検査は走りすぎても害が小さく、走らない方が問題になるため、判断の向きがコードとは逆になる。
+- **base commit を解決できない場合（初回 push・force push 等）は、全ファイルが変更されたものとして扱う**。判定不能を「変更なし」に倒すと、検査が黙って飛ぶ。
+- **変更ファイル一覧をログ（`$GITHUB_STEP_SUMMARY`）に出す**。何がスキップされたか追えないと、スキップは「検査して通った」と見分けがつかない。
+- **判定ロジックを変えたら、スキップ経路を実際に踏む PR で確認する**。全ジョブが「起動して成功」しても、それは**スキップが効いていないことの証明にはならない**。
 - 必須チェックにしないワークフロー（デプロイ等）は、ワークフローレベルの `paths-ignore` を使ってよい（起動そのものを止める方が安価）。
 
 ## デプロイの発火

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,54 @@ jobs:
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          # code は「除外リスト」で書く。対象リストにすると新しいディレクトリが増えた
-          # ときに黙ってテストが走らなくなるため、安全側に倒す。
-          # docs は逆に「対象リスト」。走りすぎても害が小さく、走らない方が問題になる。
-          filters: |
-            code:
-              - '!(docs/**|.claude/**|**/*.md|LICENSE)'
-            docs:
-              - 'docs/**'
-              - '.claude/**'
-              - '**/*.md'
-            workflows:
-              - '.github/workflows/**'
+          # 変更ファイルの算出に merge-base が必要なため全履歴を取得する。
+          fetch-depth: 0
+
+      # 判定を glob マッチャに任せず、変更ファイル一覧への明示的なパターン照合で行う。
+      # dorny/paths-filter はパターンを OR で評価するため、「docs でも .claude でも
+      # *.md でもない」という AND 条件を表現できない（単一 extglob の !(a|b) は "/" を
+      # 跨げず、.claude/rules/*.md や README.md が除外されずコードレーンが起動した）。
+      - name: Detect changed areas
+        id: filter
+        env:
+          # ${{ }} を run: に直接埋め込まず env 経由で渡す（コマンドインジェクション対策）。
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # base が取得できない場合（初回 push・force push 等）は安全側に倒し、
+          # 全ファイルが変更されたものとして扱う。
+          if [ -z "${BASE_SHA:-}" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "base commit を解決できないため、全ファイルを対象とする"
+            files=$(git ls-files)
+          else
+            files=$(git diff --name-only "$(git merge-base "$BASE_SHA" HEAD)" HEAD)
+          fi
+
+          echo "## 変更ファイル" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "$files" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          # ドキュメント扱いするパス。code はこの否定（＝除外リスト方式）で求めるため、
+          # 新しいディレクトリが増えても黙ってテストが止まることはない。
+          docs_re='(^|/)[^/]*\.md$|^docs/|^\.claude/'
+
+          code=$(printf '%s\n' "$files" | grep -vE "${docs_re}|^LICENSE$" || true)
+          docs=$(printf '%s\n' "$files" | grep -E "$docs_re" || true)
+          workflows=$(printf '%s\n' "$files" | grep -E '^\.github/workflows/' || true)
+
+          for name in code docs workflows; do
+            eval "value=\${$name}"
+            if [ -n "$value" ]; then
+              echo "${name}=true" >> "$GITHUB_OUTPUT"
+              echo "${name}: true"
+            else
+              echo "${name}=false" >> "$GITHUB_OUTPUT"
+              echo "${name}: false"
+            fi
+          done
 
   # 静的ゲート: lint / 型 / フォーマット。最速で全 PR の門番になる。
   static:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,29 +58,31 @@ jobs:
             files=$(git diff --name-only "$(git merge-base "$BASE_SHA" HEAD)" HEAD)
           fi
 
-          echo "## 変更ファイル" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo "$files" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## 変更ファイル"
+            echo '```'
+            echo "$files"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # 名前と「マッチした行」を受け取り、有無を true/false として出力する。
+          emit() {
+            if [ -n "$2" ]; then
+              echo "$1=true" >> "$GITHUB_OUTPUT"
+              echo "$1: true"
+            else
+              echo "$1=false" >> "$GITHUB_OUTPUT"
+              echo "$1: false"
+            fi
+          }
 
           # ドキュメント扱いするパス。code はこの否定（＝除外リスト方式）で求めるため、
           # 新しいディレクトリが増えても黙ってテストが止まることはない。
           docs_re='(^|/)[^/]*\.md$|^docs/|^\.claude/'
 
-          code=$(printf '%s\n' "$files" | grep -vE "${docs_re}|^LICENSE$" || true)
-          docs=$(printf '%s\n' "$files" | grep -E "$docs_re" || true)
-          workflows=$(printf '%s\n' "$files" | grep -E '^\.github/workflows/' || true)
-
-          for name in code docs workflows; do
-            eval "value=\${$name}"
-            if [ -n "$value" ]; then
-              echo "${name}=true" >> "$GITHUB_OUTPUT"
-              echo "${name}: true"
-            else
-              echo "${name}=false" >> "$GITHUB_OUTPUT"
-              echo "${name}: false"
-            fi
-          done
+          emit code      "$(printf '%s\n' "$files" | grep -vE "${docs_re}|^LICENSE$" || true)"
+          emit docs      "$(printf '%s\n' "$files" | grep -E  "$docs_re" || true)"
+          emit workflows "$(printf '%s\n' "$files" | grep -E  '^\.github/workflows/' || true)"
 
   # 静的ゲート: lint / 型 / フォーマット。最速で全 PR の門番になる。
   static:


### PR DESCRIPTION
## 概要

#55 で導入した CI 分割の `code` 判定が機能しておらず、**ドキュメントのみの PR（#57）でも `static` / `ut` / `it` / `e2e` が起動していた**。#55 の目的そのものが達成できていない状態だったため修正する。

Closes #58

## 原因

`actionlint` は正しく skipped だったため、ジョブレベル `if:` の仕組みではなく **`code` のパターン自体の誤り**だった。

1. **`dorny/paths-filter` はフィルタ内の複数パターンを OR で評価する**ため、「`docs/` でも `.claude/` でも `*.md` でもない」という **AND 条件を表現できない**
2. 単一の extglob `!(docs/**|.claude/**|**/*.md|LICENSE)` は **`/` を跨げない**

picomatch で挙動を再現して確認した:

| ファイル | 期待 | 実際（旧パターン） |
|---|---|---|
| `docs/01.md` | 除外 | ✅ 除外 |
| `LICENSE` | 除外 | ✅ 除外 |
| `.claude/rules/api.md` | 除外 | ❌ **MATCH → code=true** |
| `README.md` | 除外 | ❌ **MATCH → code=true** |
| `front/src/lib/helpers.ts` | 対象 | ✅ MATCH |

## 対応

変更ファイル一覧への**明示的なパターン照合**に置き換えた。glob マッチャの意味論に依存せず、AND 条件をそのまま書ける。

- **`code` は `docs` の否定として求める**。除外リスト方式（新しいディレクトリが増えても黙ってテストが止まらない）は維持
- **base commit を解決できない場合（初回 push・force push 等）は全ファイル変更扱い**にする。判定不能を「変更なし」に倒すと検査が黙って飛ぶため
- **変更ファイル一覧を `$GITHUB_STEP_SUMMARY` に出力**する。何がスキップされたか追えないと、スキップは「検査して通った」と見分けがつかない
- `${{ }}` を `run:` へ直接埋め込まず **env 経由で渡す**（コマンドインジェクション対策）

### ローカル検証

判定ロジックを 4 ケースで確認済み:

| ケース | 入力 | 結果 |
|---|---|---|
| docs-only（#57 の実差分） | `.claude/rules/api.md`, `.claude/rules/frontend.md` | ✅ `code=false` |
| 混在 | `docs/01.md`, `front/src/lib/helpers.ts`, `README.md` | ✅ `code=true` |
| workflow のみ | `.github/workflows/ci.yml` | ✅ `code=true` |
| 紛らわしい名前 | `front/src/markdown.ts`, `docs-helper.ts`, `LICENSE.ts` | ✅ 3 件とも `code=true`（誤除外なし） |

YAML の構文も検証済み。

## ルール側の修正

`github-actions.md` の実装例を同じ方式へ差し替えた。**動かないパターンをルールとして残すと、次に CI を書くときに同じ誤りを繰り返す**ため。

CI 修正とルール修正は通常 PR を分けているが、**今回はルールの実装例そのものが不具合の原因**であり、片方だけ直すと「main が壊れたパターンを推奨している」状態が残るため同一 PR とした。

あわせて再発防止の観点を追記した:

> **判定ロジックを変えたら、スキップ経路を実際に踏む PR で確認する**。全ジョブが「起動して成功」しても、それは**スキップが効いていないことの証明にはならない**。

## 検出が遅れた理由

#55 の検証では全 7 ジョブが「起動して成功」したことをもって green と判断した。**スキップ経路を実際に踏む PR で確認していなかった**ため、スキップが効いていないことを見逃した。#57 が docs-only だったことで初めて顕在化した。

## 検証計画

本 PR は `.github/workflows/**` を変更するため `code=true` となり、全レーンが起動する（意図どおり）。**スキップ経路の実証は、本 PR マージ後の #57 の再実行で行う**（#57 は docs-only）。

## ドキュメント同期（`.claude/rules/documentation.md` 影響マップ）

- ビルド・実行・設定（ワークフロー）の変更 → CI の判定ロジックのみの変更で、開発者が叩くコマンドに変更はないため README.md / CLAUDE.md の更新は不要
- 開発ルール / 規約の変更 → `github-actions.md` の実装例を更新。新規ファイルの追加はなく Rules テーブルの変更は不要

## テスト

CI 設定とルールドキュメントのみの変更。アプリケーションコードは変更していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)