### PR TITLE
docs(rules): database.md にスキーマの実態を明記する

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -13,6 +13,25 @@ globs: "front/prisma/**,front/src/lib/server/**"
 - 実行コマンド: `cd front && pnpm prisma:pull`。pull 前後で `pnpm prisma:validate` / `pnpm prisma:generate` を実行する。
 - テーブル定義の反映（push）は別プロジェクト側で実施する。反映完了後、このリポジトリで再度 `db pull` して同期する。
 
+### `prisma migrate` を採用しない
+
+**マイグレーションファイルによる管理（`prisma migrate dev` / `migrate deploy`）は本プロジェクトでは採用しない。** スキーマの正は共有 Supabase プロジェクト側にあり、このリポジトリは `db pull` でその写しを取るだけだからである。マイグレーション履歴をこちら側に持つと、**正が 2 箇所になり必ず乖離する**。
+
+一般的な Prisma のプラクティスは `migrate` を前提とするため、外部の手順やテンプレートを取り込む際は**この節と矛盾しないか必ず確認する**。
+
+### `schema.prisma` に他プロジェクトのモデルが含まれる
+
+共有 Supabase プロジェクトを他プロジェクトと共用しているため、`db pull` すると**そのプロジェクトの全テーブルが引かれる**。現在 12 モデル中 9 モデルが本プロジェクトと無関係である。
+
+| 区分 | モデル |
+|---|---|
+| **本プロジェクト** | `BookRecordBook` / `BookRecordProgressLog` / `BookRecordReflection`（+ enum `BookRecordStatus` / `BookRecordFormat`） |
+| **他プロジェクト（触らない）** | `ExerciseCardio` / `ExerciseMaster` / `ExerciseProfile` / `ExerciseRecord` / `ExerciseWorkout` / `Report` / `ReportTag` / `ReportTagMapping` / `VideoEntry` |
+
+- **他プロジェクトのモデルを編集・削除しない。** `db pull` で再生成されるため差分は無意味であり、削除しても次回 pull で復活する。
+- **`BookRecord` 接頭辞は、この共用環境における名前空間の分離手段**である。新しいテーブルを追加する際も必ず接頭辞を付ける（`命名規約` を参照）。
+- `PrismaBookRecordRepository` は `BookRecord*` モデルのみを扱う。他プロジェクトのモデルにアクセスしない。
+
 ### 例外: テストコンテナへの `db push`
 
 - **IT / E2E のテスト用 Postgres コンテナに限り `prisma db push` を許可する**。使い捨てコンテナへ `schema.prisma` を materialize する目的で、共有 Supabase プロジェクトには一切接続しない。
@@ -27,6 +46,28 @@ globs: "front/prisma/**,front/src/lib/server/**"
   - `BookRecordReflection`（table `BookRecordReflections`）
 - フィールド名: camelCase（例: `bookId`, `createdAt`, `loggedAt`）。
 - 論理モデル（`Book` / `ProgressLog` / `Reflection`）は `local` / `supabase` の両モードで維持する（`docs/05-data-specification.md`）。
+
+## 共通フィールド
+
+テーブル定義は別プロジェクト側で行うため、ここでは**このリポジトリが期待する形**を定める。`db pull` した結果がこれと食い違う場合は、別プロジェクト側の定義を直す。
+
+| フィールド | 期待する定義 | 備考 |
+|---|---|---|
+| `id` | `String @id @default(uuid()) @db.Uuid` | 連番は使わない（列挙による他レコードの推測を防ぐ） |
+| `createdAt` | `DateTime @default(now()) @map("created_at")` | |
+| `updatedAt` | `DateTime @updatedAt @map("updated_at")` | |
+
+- 物理カラム名は snake_case、Prisma のフィールド名は camelCase とし、`@map` で対応させる（`命名規約`）。
+- **追記専用テーブルは `createdAt` / `updatedAt` を持たなくてよい**。`BookRecordProgressLog` は進捗の追記のみで更新・削除しないため、**記録時刻を表す `loggedAt` だけを持つ**。これは漏れではなく意図的な設計であり、同種のテーブルを追加する場合も同じ扱いでよい。
+- 状態の到達時刻など**業務上の意味を持つ日時**は、共通フィールドとは別に定義する（例: `BookRecordBook.completedAt` は完読日時であり、`updatedAt` とは意味が異なる）。
+
+## 削除方針（論理削除を採用しない）
+
+**論理削除（`deletedAt` によるソフトデリート）は採用しない。** 現在、全 12 モデルに `deletedAt` は存在しない。
+
+- 削除は**物理削除**とし、関連レコードは `onDelete: Cascade` で追随させる（`BookRecordProgressLog` / `BookRecordReflection` は `BookRecordBook` の削除で消える）。
+- 単一ユーザー向け MVP であり、**削除の取り消し・監査要件が無い**ため。論理削除を採用すると、全読み取りクエリに `where: { deletedAt: null }` の付与が必要になり、付け忘れが情報漏洩に直結する。
+- **方針を変える場合はルールを先に更新する。** 一部のテーブルだけ論理削除にすると、削除の意味がテーブルごとに変わり、結合時に消えたはずのデータが現れる。
 
 ## クエリ
 

--- a/docs/05-data-specification.md
+++ b/docs/05-data-specification.md
@@ -18,7 +18,8 @@
 - [5. データ破損と復旧（`local` モード）](#5-データ破損と復旧local-モード)
 - [6. バージョン移行（`local` モード）](#6-バージョン移行local-モード)
 - [7. DBスキーマ（`supabase` モード）](#7-dbスキーマsupabase-モード)
-- [8. 拡張方針](#8-拡張方針)
+- [8. 削除方針](#8-削除方針)
+- [9. 拡張方針](#9-拡張方針)
 
 ## 1. 目的
 
@@ -164,8 +165,17 @@ erDiagram
   - `BookRecordProgressLogs`（model `BookRecordProgressLog`）
   - `BookRecordReflections`（model `BookRecordReflection`）
 - スキーマ同期フロー（`db pull` 運用）は `docs/09-architecture-specification.md` を参照する。
+- 共有 Supabase プロジェクトを他プロジェクトと共用しているため、`db pull` すると**他プロジェクトのテーブルも `schema.prisma` に含まれる**（現在 12 モデル中 9 モデル）。`BookRecord` 接頭辞はその名前空間の分離手段であり、他プロジェクトのモデルは編集・削除しない。
 
-## 8. 拡張方針
+## 8. 削除方針
+
+- **論理削除（ソフトデリート）は採用せず、物理削除とする。** `deletedAt` 相当のフィールドは持たない。
+- `BookRecordBook` を削除すると、関連する `BookRecordProgressLog` / `BookRecordReflection` は `onDelete: Cascade` により同時に削除される。
+- 理由: 単一ユーザー向け MVP であり、削除の取り消し・監査要件が無い。論理削除は全読み取りクエリへの除外条件付与を要求し、付け忘れが情報漏洩に直結する。
+- `local` モードでも同様に、`StoragePayload` から対象レコードと関連レコードを取り除く。
+- 方針を変更する場合は本節と `.claude/rules/database.md` を先に更新する（テーブルごとに削除の意味が変わる状態を作らない）。
+
+## 9. 拡張方針
 
 - `supabase` / `local` のどちらでも `Book` / `ProgressLog` / `Reflection` の論理モデルは維持する
 - 既存ローカルデータのインポートは別タスクで設計する


### PR DESCRIPTION
## 概要

`/rules-update` のテンプレート（`database/prisma.md`）と突合して検出した未適用 3 節を、本プロジェクトの実態に合わせて反映する。

Closes #61

## 1. 「`prisma migrate` を採用しない」— 判断の記録

テンプレートは `prisma migrate dev` / `migrate deploy` を指示しているが、本プロジェクトは **`migrate` 禁止・`db pull` 運用**。**取り込んではいけない**節である。

そのまま「書かない」で済ませると、**次にテンプレートや外部手順を取り込むときに同じ判断を再度迫られる**（実際、今回の突合で「なぜ無いのか」を判別できなかった）。採用しない理由を明記した:

> スキーマの正は共有 Supabase プロジェクト側にあり、このリポジトリは `db pull` でその写しを取るだけ。マイグレーション履歴をこちら側に持つと、**正が 2 箇所になり必ず乖離する**。

## 2. 「`schema.prisma` に他プロジェクトのモデルが含まれる」— 新規追加

突合中に見つけた事実。**12 モデル中 9 モデルが本プロジェクトと無関係**（`ExerciseCardio` / `ExerciseMaster` / `ExerciseProfile` / `ExerciseRecord` / `ExerciseWorkout` / `Report` / `ReportTag` / `ReportTagMapping` / `VideoEntry`）。共有 Supabase プロジェクトを共用しており、`db pull` が全テーブルを引くため。

ルールに記載が無く、**初見では「なぜ関係ないテーブルがあるのか」「消してよいのか」が判断できない**状態だった。区分表と以下を明記:

- 他プロジェクトのモデルを**編集・削除しない**（`db pull` で再生成されるため差分は無意味で、削除しても次回 pull で復活する）
- **`BookRecord` 接頭辞はこの共用環境における名前空間の分離手段**である

## 3. 「共通フィールド」— 期待する形として定義

テーブル定義は別プロジェクト側で行うため、テンプレートの「全モデルにこれを含める」をそのままは書けない。**このリポジトリが期待する形**として定義し、`db pull` の結果が食い違う場合は別プロジェクト側を直す、という運用にした。

実スキーマ（`BookRecord*`）を確認した上での重要な追記:

> **追記専用テーブルは `createdAt` / `updatedAt` を持たなくてよい**。`BookRecordProgressLog` は進捗の追記のみで更新・削除しないため、記録時刻を表す `loggedAt` だけを持つ。**これは漏れではなく意図的な設計**である。

規約だけ書くと `ProgressLog` が違反に見えてしまうため、例外として明示した。

## 4. 「削除方針（論理削除を採用しない）」

`deletedAt` は**全 12 モデルで 0 件**。削除は `onDelete: Cascade` の物理削除。「採用していない」と書かないと、新規テーブル追加時に判断が揺れる。

理由も残した: 論理削除は**全読み取りクエリへの `where: { deletedAt: null }` 付与を要求し、付け忘れが情報漏洩に直結する**。単一ユーザー MVP で取り消し・監査要件が無いため採用しない。

**この節は #9（書籍を削除できるようにする）の前提になる。** 削除の実装方針が未定義のままでは着手できないため。

## docs/05 への反映

`.claude/rules/documentation.md` の影響マップでは**永続化仕様は `docs/05-data-specification.md` が担当**であり、削除方針の記載が無かったため §8 として追加した。

- 既存の §8「拡張方針」を §9 へ繰り下げ、目次も更新
- **節番号を参照している箇所が無いことを確認済み**（`grep` で `§8` 参照ゼロ）
- 目次アンカーの実在をスクリプトで検証（未解決 0 件）
- §7 に他プロジェクトのモデル混在についても追記

ルール（`.claude/rules/database.md`）は「実装時にどう振る舞うか」、仕様書（`docs/05`）は「データの仕様」として、重複を最小にしつつ双方から辿れるようにした。

## 検証

| 項目 | 結果 |
|---|---|
| `markdownlint-cli2` | ✅ `0 issues in 0 files` |
| `docs/05` の目次アンカー | ✅ 未解決 0 件 |
| 記載内容と実スキーマの一致 | ✅ `schema.prisma` を直接確認（uuid 主キー・`@map` の snake_case・`onDelete: Cascade`・`deletedAt` 0 件） |

## ドキュメント同期（`.claude/rules/documentation.md` 影響マップ）

- **データモデル / 永続化仕様の変更** → `docs/05-data-specification.md` を更新済み。**`front/prisma/` の変更は無し**（スキーマ自体は変更しておらず、既存の実態を文書化しただけ）
- 開発ルール / 規約の変更 → `.claude/rules/database.md` を更新。新規ファイルの追加はなく `CLAUDE.md` の Rules テーブルに変更は不要
- 上記以外 → 該当なし

## テスト

ドキュメントのみの変更。アプリケーションコード・スキーマは変更していない。

**本 PR も docs-only のため `code` レーンはスキップされる想定。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)