### PR TITLE
refactor(types): lib/types.ts の interface を type に統一する

### DIFF
--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -11,15 +11,15 @@ export type BookFormat = "paper" | "ebook" | "audio";
  * 完読時の感想。学び / 行動 / 一文はいずれも空入力可で、
  * 3項目すべてが空（trim 後）なら「感想未記入」として扱う（helpers.reflectionIsMissing）。
  */
-export interface Reflection {
+export type Reflection = {
   learning: string;
   action: string;
   quote: string;
   createdAt: string;
-}
+};
 
 /** 書籍1冊のドメインモデル。`local` / `supabase` の両モードで共通の論理形。 */
-export interface Book {
+export type Book = {
   id: string;
   title: string;
   author: string;
@@ -36,30 +36,30 @@ export interface Book {
   completedAt?: string;
   /** 完読時感想。再読しても保持する（初期化しない）。 */
   reflection?: Reflection;
-}
+};
 
 /** 進捗記録1件。追記のみで更新・削除しない（進捗履歴）。 */
-export interface ProgressLog {
+export type ProgressLog = {
   id: string;
   bookId: string;
   page: number;
   memo?: string;
   status: BookStatus;
   loggedAt: string;
-}
+};
 
 /**
  * `local` モードで localStorage に保存する永続化ペイロード。
  * `version` はスキーマ判定に使い、不一致・破損時は初期化する（helpers.parseStoragePayload）。
  */
-export interface StoragePayload {
+export type StoragePayload = {
   version: number;
   books: Book[];
   progressLogs: ProgressLog[];
-}
+};
 
 /** 書籍作成の入力。初期ステータスに `completed` は指定できない（型で除外）。 */
-export interface CreateBookInput {
+export type CreateBookInput = {
   title: string;
   author: string;
   genre?: string;
@@ -67,10 +67,10 @@ export interface CreateBookInput {
   totalPages: number;
   tags: string[];
   status: Exclude<BookStatus, "completed">;
-}
+};
 
 /** 書籍更新の入力。指定したフィールドのみ部分更新する（再読・完読の状態変更を含む）。 */
-export interface UpdateBookInput {
+export type UpdateBookInput = {
   title?: string;
   author?: string;
   genre?: string;
@@ -82,26 +82,26 @@ export interface UpdateBookInput {
   /** 明示的に undefined を渡すと完読解除（再読）を表現する。 */
   completedAt?: string | undefined;
   reflection?: Reflection;
-}
+};
 
 /** 進捗記録の入力。`loggedAt` 省略時は現在時刻を記録日とする。 */
-export interface CreateProgressLogInput {
+export type CreateProgressLogInput = {
   page: number;
   memo?: string;
   status: BookStatus;
   loggedAt?: string;
-}
+};
 
 /** 感想保存の入力（3項目とも空入力可）。 */
-export interface ReflectionInput {
+export type ReflectionInput = {
   learning: string;
   action: string;
   quote: string;
-}
+};
 
 /** 直近7日（当日含む）の週次集計結果。 */
-export interface WeeklySummary {
+export type WeeklySummary = {
   readPages: number;
   progressCount: number;
   reflectionCount: number;
-}
+};


### PR DESCRIPTION
## 概要

`.claude/rules/typescript.md`「type vs interface」と実装の乖離を解消する。

Closes #64

規約は次のように定めている:

> **原則 `type` を使う。** `interface` は **class が `implements` / `extends` する契約**、または**宣言マージが必要**な場合のみ。

`lib/types.ts` の 9 件はいずれも**データの形**（ドメインモデル / 入力 DTO / 集計結果）であり、条件のどちらにも該当していなかった。

## 変更内容

| 対象 | 対応 |
|---|---|
| `Reflection` / `Book` / `ProgressLog` / `StoragePayload` / `CreateBookInput` / `UpdateBookInput` / `CreateProgressLogInput` / `ReflectionInput` / `WeeklySummary` | `interface` → `type` |
| **`BookRepository`（`lib/repository.ts`）** | **`interface` のまま維持** |

`BookRepository` は `ApiRepository` / `LocalStorageRepository` / `PrismaBookRecordRepository` の **3 クラスが `implements` している**ため、規約の条件 1 に該当する。一括変換すると壊れる箇所なので、意図的に除外した。

JSDoc（型本体・各メンバー）はすべて維持している（`jsdoc.md`「型定義のコメント」）。

## 事前確認

変換の安全性を、機械的に置換する前に確認した。

| 確認項目 | 結果 |
|---|---|
| `interface X extends Y` の使用 | **なし**（交差型への置き換えが不要） |
| interface の宣言マージ | **なし** |
| `declare global` / `declare module` | `prisma-client.ts` に 1 件あるが **`var` 宣言**であり interface ではない → 影響なし |

利用側の `import` は変更不要（`interface` と `type` はオブジェクト形状として互換）。

## 検証

ローカルで全て実行済み。

| 項目 | 結果 |
|---|---|
| `tsc --noEmit` | ✅ エラーなし |
| `pnpm lint` | ✅ 指摘なし |
| `pnpm format:check` | ✅ Prettier 準拠 |
| `pnpm test`（UT） | ✅ **9 ファイル / 112 テスト すべて成功** |

IT（Docker Postgres）と E2E（Playwright）は CI で実行される。**本 PR はコード変更のため `code` レーンが起動し、全 7 ジョブが走る**（`docs` レーンは `.claude/` も `.md` も触っていないためスキップされる想定）。

## 意義

型定義に関する規約と実装が一致した状態になり、**残る機能 issue（#9〜#12）がいずれも `lib/types.ts` に触る**ため、着手前に片付けることで差分の混在を避けられる。

- #11 著者名を任意入力に → `Book.author` / `CreateBookInput.author`
- #12 総ページ数未入力でも読了に → `Book.totalPages`
- #10 書影表示 → `Book` へフィールド追加
- #9 書籍削除 → `BookRepository` の契約追加

## ドキュメント同期（`.claude/rules/documentation.md` 影響マップ）

- **データモデル / 永続化仕様の変更 → 該当なし。** 型の**宣言方法**を変えただけで、フィールド・型・意味は一切変わっていないため `docs/05-data-specification.md` の更新は不要
- Repository インターフェース / API 契約の変更 → **該当なし**（`BookRepository` は未変更）
- 上記以外 → 該当なし

## テスト

型宣言の構文変更のみで、ランタイムの挙動は変わらない（`type` / `interface` はいずれもコンパイル後に消える）。**テストの追加は不要**と判断し、既存の UT 112 件が全て通ることで回帰がないことを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)